### PR TITLE
feat(frontend): prompt user to use mevblocker once

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -22,6 +22,7 @@ import { enableSwapInformation } from 'src/utils/featureFlags';
 import { useUsdValue } from 'src/hooks/useUsdValue';
 import { useExecuteSwap } from 'src/hooks/useExecuteSwap';
 import { useDepositMax } from 'src/hooks/useDepositMax';
+import { useSuggestMevProtection } from 'src/hooks/useSuggestMevProtection';
 import { SwapDetails } from '../SwapDetails/SwapDetails';
 
 const CreateSwap = () => {
@@ -30,6 +31,7 @@ const CreateSwap = () => {
   useReferrer();
   useDefaultTokens();
   const { handleSubmit } = useForm();
+  useSuggestMevProtection();
   const {
     fromToken: fromTokenSymbol,
     toToken: toTokenSymbol,

--- a/packages/frontend/src/hooks/useSuggestMevProtection.ts
+++ b/packages/frontend/src/hooks/useSuggestMevProtection.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { showToast } from "@sifi/shared-ui";
+import { useWalletClient } from "wagmi";
+import { mainnet } from 'viem/chains';
+import { localStorageKeys } from "src/utils/localStorageKeys";
+
+const MEVBlockerRPCUrl = 'https://mevblocker.io/#rpc';
+
+// NOTE: No consistent way to detect if user is already uising MEVBlocker
+const useSuggestMevProtection = () => {
+  const { data: walletClient } = useWalletClient();
+
+  const updateRpcUrl = () => {
+    window.open(MEVBlockerRPCUrl, '_blank');
+    localStorage.setItem(localStorageKeys.HAS_SUGGESTED_PROTECTED_RPC, 'true');
+  };
+
+  const suggestProtectedRPC = () => {
+    showToast({
+      type: 'info',
+      text: 'We suggest you use MEV protection to avoid sandwich attacks.',
+      action: { text: 'Add protected RPC', onClick: updateRpcUrl },
+    });
+  };
+
+  useEffect(() => {
+    if (!walletClient || walletClient.chain.id !== mainnet.id) return;
+
+    const hasSuggestedProtectedRPC = localStorage.getItem(localStorageKeys.HAS_SUGGESTED_PROTECTED_RPC);
+    if (!hasSuggestedProtectedRPC) {
+      suggestProtectedRPC();
+    }
+  }, [walletClient?.chain])
+};
+
+export { useSuggestMevProtection };

--- a/packages/frontend/src/utils/localStorageKeys.ts
+++ b/packages/frontend/src/utils/localStorageKeys.ts
@@ -2,6 +2,7 @@ const localStorageKeys = {
   REFFERRER_ADDRESS: 'referrerAddress',
   REFERRER_FEE_BPS: 'referrerFeeBps',
   SWAP_HISTORY: 'swapHistory',
+  HAS_SUGGESTED_PROTECTED_RPC: 'hasSuggestedProtectedRpc',
 } as const;
 
 export { localStorageKeys };


### PR DESCRIPTION
### Changes Made

 - The first time a user connects to the site on mainnet, suggest they use the MEVBlocker RPC to prevent attacks.

### Additional Notes

 - There is no way to reliably check if a user is already using MEVBlocker
   - Brave Wallet responds `true` to `eth_mevblocker`, but Metamask does not.
   - Removed check entirely since we cannot guarantee a consistent experience cross wallet.
   - Relying solely on local storage flag.
 - Rather than addding the network directly, we link a user to https://mevblocker.io/#rpc so they can learn what they are doing prior to adding the RPC. (They have a convenient button on their site) 

### Screenshots/videos
 
### Testing

 - [X] New users connecting to mainnet are prompted with a toast.
 - [X] Toast does not show more than once for same browser.
 - [X] Clicking toast button prompts wallet to add MEVBlocker RPC
 - [X] Metamask
 - [X] Brave Wallet
 - [X] Coinbase Wallet
 - [X] WalletConnect

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.

