### PR TITLE
fix(frontend): use routes for referral links

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -31,7 +31,9 @@ const App = () => {
     <AppProvider>
       <Layout>
         <Routes>
+          <Route path="/:ref" element={<Home />} />
           <Route path="/:fromToken/:toToken" element={<Home />} />
+          <Route path="/:fromToken/:toToken/:ref" element={<Home />} />
           <Route path="*" element={<Home />} />
         </Routes>
       </Layout>

--- a/packages/frontend/src/hooks/useReferrer.ts
+++ b/packages/frontend/src/hooks/useReferrer.ts
@@ -1,19 +1,18 @@
 import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { localStorageKeys } from 'src/utils/localStorageKeys';
-import { searchParams } from 'src/utils/routes';
 import { isAddress } from 'viem';
 
+const REFERRER_ADDRESS_LENGTH = 42;
+
 const useReferrer = () => {
-  const [searchParamsFromUrl] = useSearchParams();
-  const navigate = useNavigate();
+  const { ref: refParam } = useParams();
 
   useEffect(() => {
-    const refParam = searchParamsFromUrl.get(searchParams.REFERRER);
 
     if (!refParam) return;
 
-    const referrerAddress = refParam.slice(0, 42);
+    const referrerAddress = refParam.slice(0, REFERRER_ADDRESS_LENGTH);
 
     if (!isAddress(referrerAddress)) {
       console.error('Invalid Referrer Address. Address should be 42 characters');
@@ -33,9 +32,7 @@ const useReferrer = () => {
       // In case there is a new referral address without a set fee bps, we remove the old one
       localStorage.removeItem(localStorageKeys.REFERRER_FEE_BPS);
     }
-
-    navigate('/');
-  }, [searchParamsFromUrl]);
+  }, []);
 };
 
 export { useReferrer };

--- a/packages/frontend/src/hooks/useSyncTokenUrlParams.ts
+++ b/packages/frontend/src/hooks/useSyncTokenUrlParams.ts
@@ -97,7 +97,7 @@ const useSyncTokenUrlParams = () => {
   // Update url params if the user changes the from or to token
   useEffect(() => {
     if (!isSynchronised && fromToken?.address && toToken?.address) {
-      navigate(`/${fromToken.address}${fromChain.id}/${toToken.address}${toChain.id}`);
+      navigate(`/${fromToken.address}${fromChain.id}/${toToken.address}${toChain.id}`, { replace: true });
     }
   }, [fromToken, toToken]);
 };

--- a/packages/frontend/src/utils/routes.ts
+++ b/packages/frontend/src/utils/routes.ts
@@ -1,5 +1,0 @@
-const searchParams = {
-  REFERRER: 'ref',
-} as const;
-
-export { searchParams };


### PR DESCRIPTION
### Changes Made

 - Using search params with the hash router the way we want to is broken when combined with the token swap routing.
 - Uses routes to handle referrer addresses

### Additional Notes

 - Valid routes for referrers are now `sifi.org/#/<ADDRESS><BASIS_POINTS>` or `sifi.org/#/<TOKEN_ADDRESS_1><CHAIN_ID_1>/<TOKEN_ADDRESS_2><CHAIN_ID_2>/<ADDRESS><BASIS_POINTS>`
 - The `#` is required.

### Testing

 - [X] Used both routes above, referrer and basis points are set in `localStorage`

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
