### PR TITLE
feat(frontend): set default swap pair to eth mainnet -> usdc arbitrum

### DIFF
--- a/packages/frontend/src/hooks/useDefaultTokens.tsx
+++ b/packages/frontend/src/hooks/useDefaultTokens.tsx
@@ -3,6 +3,8 @@ import { useFormContext } from 'react-hook-form';
 import { useTokens } from 'src/hooks/useTokens';
 import { SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
 
+const DEFAULT_TO_TOKEN_SYMBOL = 'USDC';
+
 const useDefaultTokens = () => {
   const { setValue } = useFormContext();
   const fromTokenKey = SwapFormKeyHelper.getTokenKey('from');
@@ -17,7 +19,7 @@ const useDefaultTokens = () => {
 
   useEffect(() => {
     if (toTokens.length > 1) {
-      setValue(toTokenKey, toTokens[1].symbol);
+      setValue(toTokenKey, DEFAULT_TO_TOKEN_SYMBOL);
     }
   }, [toTokens, setValue]);
 };

--- a/packages/frontend/src/providers/SwapFormProvider.tsx
+++ b/packages/frontend/src/providers/SwapFormProvider.tsx
@@ -28,11 +28,11 @@ export type SwapFormType = 'from' | 'to';
 
 export const formDefaultValues = {
   [SwapFormKey.FromAmount]: '',
-  [SwapFormKey.FromChain]: SUPPORTED_CHAINS[0],
+  [SwapFormKey.FromChain]: SUPPORTED_CHAINS[0], // Mainnet
   [SwapFormKey.FromToken]: null,
   [SwapFormKey.ToAmount]: '',
   [SwapFormKey.ToAddress]: '',
-  [SwapFormKey.ToChain]: SUPPORTED_CHAINS[0],
+  [SwapFormKey.ToChain]: SUPPORTED_CHAINS[1], // Arbitrum
   [SwapFormKey.ToToken]: null,
   [SwapFormKey.TokenSearchFilter]: '',
 };


### PR DESCRIPTION
Trivial, no template.

 - Set default target chain to Arbitrum
 - Set default to token to USDC

Better demonstrates cross chain capabilities to new users.

![image](https://github.com/sifiorg/sifi/assets/112887817/5da41570-6bcc-4f72-b25d-77b6327c7a69)
