### PR TITLE
feat(frontend): show recent swaps

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Hero } from './components/Hero/Hero';
 import { Route, Routes } from 'react-router-dom';
 import { SpaceTravelCanvas } from './space-travel/SpaceTravelCanvas';
 import { Stats } from './components/Stats/Stats';
+import { RecentWarps } from './components/RecentWarps/RecentWarps';
 
 const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
   return (
@@ -26,6 +27,7 @@ const Home: FunctionComponent = () => {
     <>
       <div className="mt-12 flex min-h-[90vh] flex-col md:mt-0 md:justify-center">
         <Hero />
+        <RecentWarps />
       </div>
     </>
   );

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.stories.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.stories.tsx
@@ -1,0 +1,27 @@
+import { rest } from 'msw';
+import { StoryFn } from '@storybook/react';
+import isChromatic from 'chromatic/isChromatic';
+import { RecentWarps } from './RecentWarps';
+import GRAPH_URLS from 'src/subgraph.json';
+
+export default {
+  title: 'Components/RecentWarps',
+  component: RecentWarps,
+};
+
+const Template: StoryFn<typeof RecentWarps> = () => <RecentWarps />;
+
+export const Default: StoryFn = Template.bind({});
+
+// TODO: Fix loading story
+export const Loading: StoryFn = Template.bind({});
+Loading.parameters = {
+  msw: [
+    rest.get(GRAPH_URLS[1], (_req, res, ctx) => {
+      return res(ctx.delay(isChromatic() ? 5000 : 'infinite'));
+    }),
+  ],
+};
+
+// TODO: Fix error story
+export const Error: StoryFn = Template.bind({});

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -100,7 +100,7 @@ const RecentWarps: FunctionComponent = () => {
     <section>
       <div className="mx-auto w-full max-w-2xl py-16">
         <div className="flex flex-col items-center justify-between gap-8">
-          <h2 className="mb-4 text-center text-3xl sm:mb-8">Recent Swaps on {fromChain.name}</h2>
+          <h2 className="mb-4 text-center text-3xl sm:mb-8">Recent Swaps from {fromChain.name}</h2>
           <div className="dark:border-darker-gray border-smoke w-full border-t">
             <Table>
               <thead>

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -1,0 +1,129 @@
+import { Table, formatTokenAmount, Skeleton } from '@sifi/shared-ui';
+import { FunctionComponent } from 'react';
+import { useRecentWarps } from 'src/hooks/useRecentWarps';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
+import { useTokens } from 'src/hooks/useTokens';
+import { getIconFromSymbol } from 'src/utils';
+
+const RecentWarpsTableData: FunctionComponent = () => {
+  const { data: warps, error, isLoading } = useRecentWarps();
+  const { fromTokens } = useTokens();
+
+  if (error) {
+    return (
+      <Table.Row width="100%">
+        <Table.Cell className="text-center">
+          <span className="dark:text-punk-red">Something went wrong loading the recent warps</span>
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        {new Array(5).fill(0).map((_, index) => (
+          <Table.Row key={`recent-shifts-table-skeleton-${index}`}>
+            <Table.Cell width="100%" className="text-center sm:hidden">
+              <Skeleton className="h-12 w-1/2 rounded-md" />
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {warps?.map(warp => {
+        return (
+          <Table.Row className="overflow-y-auto max-w-xs m-auto sm:max-w-none" key={warp.addedAt}>
+            <Table.Cell className="mb-2 w-full sm:mb-0">
+              <div className="mx-auto grid items-center sm:grid-cols-[3fr_1fr_3fr]">
+                <div className="mb-4 grid grid-cols-[1fr_3fr] sm:mb-0 sm:inline-block sm:pl-8">
+                  <span className="dark:text-flashbang-white text-new-black font-medium uppercase sm:hidden">
+                    From
+                  </span>
+                  <div className="flex items-center">
+                    <img
+                      className="mr-3 h-6 w-6 rounded-full"
+                      src={getIconFromSymbol(warp.tokenIn.symbol, fromTokens)}
+                      alt="Logo"
+                    />
+                    <span>{`${formatTokenAmount(warp.amountInDecimal)} ${
+                      warp.tokenIn.symbol
+                    }`}</span>
+                  </div>
+                </div>
+
+                <div className="hidden sm:flex justify-center">
+                  <svg
+                    width="28"
+                    height="18"
+                    viewBox="0 0 28 18"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M14.0071 0.547428L14.0071 0.547448L14.0115 0.549962L27.3296 8.24029C27.3296 8.24029 27.3296 8.2403 27.3296 8.2403C27.4515 8.31087 27.5 8.41639 27.5 8.51844C27.5 8.62043 27.4505 8.73883 27.3201 8.8242L14.0178 16.5053C13.7521 16.6459 13.4718 16.384 13.5572 16.1278L13.5583 16.1245L14.8253 12.235L15.0386 11.5801L14.3499 11.5801L0.825046 11.5801C0.6413 11.5801 0.5 11.4326 0.5 11.2551L0.5 5.80389C0.5 5.62014 0.647488 5.47884 0.825046 5.47884L14.3499 5.47884L15.0386 5.47884L14.8253 4.82397L13.5591 0.936954C13.559 0.936609 13.5589 0.936265 13.5588 0.935922C13.457 0.615508 13.7747 0.410049 14.0071 0.547428Z"
+                      stroke="#B4BBC6"
+                    />
+                  </svg>
+                </div>
+                <div className="grid grid-cols-[1fr_3fr] sm:inline-block">
+                  <span className="dark:text-flashbang-white text-new-black font-medium uppercase sm:hidden">
+                    To
+                  </span>
+                  <div className="flex items-center sm:pl-8">
+                    <img
+                      className="mr-3 h-6 w-6 rounded-full"
+                      src={getIconFromSymbol(warp.tokenOut.symbol, fromTokens)}
+                      alt="Logo"
+                    />
+                    <span>{`${formatTokenAmount(warp.amountOutDecimal)} ${
+                      warp.tokenOut.symbol
+                    }`}</span>
+                  </div>
+                </div>
+              </div>
+            </Table.Cell>
+          </Table.Row>
+        );
+      })}
+    </>
+  );
+};
+
+const RecentWarps: FunctionComponent = () => {
+  const { fromChain } = useSwapFormValues();
+  return (
+    <section>
+      <div className="mx-auto w-full max-w-2xl py-16">
+        <div className="flex flex-col items-center justify-between gap-8">
+          <h2 className="mb-4 text-center text-3xl sm:mb-8">Recent Swaps on {fromChain.name}</h2>
+          <div className="dark:border-darker-gray border-smoke w-full border-t">
+            <Table>
+              <thead>
+                <Table.Row>
+                  <Table.Heading className="w-full">
+                    <div className="mx-auto grid max-w-2xl sm:grid-cols-[3fr_1fr_3fr]">
+                      <span className="font-text col-span-2 inline-block font-medium sm:pl-8">
+                        From
+                      </span>
+                      <span className="font-text font-medium sm:pl-8">To</span>
+                    </div>
+                  </Table.Heading>
+                </Table.Row>
+              </thead>
+              <Table.Body>
+                <RecentWarpsTableData />
+              </Table.Body>
+            </Table>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export { RecentWarps };

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -24,8 +24,8 @@ const RecentWarpsTableData: FunctionComponent = () => {
       <>
         {new Array(5).fill(0).map((_, index) => (
           <Table.Row key={`recent-shifts-table-skeleton-${index}`}>
-            <Table.Cell width="100%" className="text-center sm:hidden">
-              <Skeleton className="h-12 w-1/2 rounded-md" />
+            <Table.Cell width="100%" className="text-center">
+              <Skeleton className="sm:h-10 sm:w-100 m-auto rounded-md h-20" />
             </Table.Cell>
           </Table.Row>
         ))}

--- a/packages/frontend/src/hooks/useRecentWarps.tsx
+++ b/packages/frontend/src/hooks/useRecentWarps.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import { request, gql } from 'graphql-request';
+import GRAPH_URLS from 'src/subgraph.json';
+import { useSwapFormValues } from './useSwapFormValues';
+
+const RECENT_WARPS_QUERY = gql`
+  query recentWarps($since: BigInt!) {
+    warps(first: 5, where: { addedAt_gt: $since }, orderBy: addedAt, orderDirection: desc) {
+      addedAt
+      amountInDecimal
+      tokenIn {
+        symbol
+      }
+      amountOutDecimal
+      amountOut
+      tokenOut {
+        symbol
+      }
+    }
+  }
+`;
+
+type Warp = {
+  addedAt: string;
+  amountInDecimal: string;
+  tokenIn: {
+    symbol: string;
+  };
+  amountOutDecimal: string;
+  amountOut: string;
+  tokenOut: {
+    symbol: string;
+  };
+};
+
+type RecentWarpsResponse = {
+  warps: Warp[];
+};
+
+type GraphUrls = {
+  [key: string]: string;
+};
+
+const useRecentWarps = () => {
+  const { fromChain } = useSwapFormValues();
+
+  return useQuery(
+    ['recentWarps', fromChain.id.toString()],
+    async () => {
+      const url = (GRAPH_URLS as GraphUrls)[fromChain.id];
+      const response: RecentWarpsResponse = await request(url, RECENT_WARPS_QUERY, { since: '0' });
+
+      return response.warps as Warp[];
+    },
+    {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: false,
+    }
+  );
+};
+
+export { useRecentWarps };

--- a/packages/frontend/src/utils/getIconFromSymbol.tsx
+++ b/packages/frontend/src/utils/getIconFromSymbol.tsx
@@ -1,0 +1,18 @@
+import { Token } from '@sifi/sdk';
+import { getTokenBySymbol } from './tokens';
+import MissingTokenIcon from 'src/assets/icons/missing-token-icon.svg';
+
+const getIconFromSymbol = (symbol: string, tokens: Token[]) => {
+  let logoURI = getTokenBySymbol(symbol, tokens)?.logoURI;
+
+  // Symbol from the SDK is sometimes inconsistent
+  if (!logoURI) {
+    const processedSymbol = symbol.includes('.')
+      ? symbol.split('.')[0].toUpperCase()
+      : symbol.toUpperCase();
+    logoURI = getTokenBySymbol(processedSymbol, tokens)?.logoURI;
+  }
+  return logoURI || MissingTokenIcon;
+};
+
+export { getIconFromSymbol };

--- a/packages/frontend/src/utils/index.ts
+++ b/packages/frontend/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './getViemErrorMessage';
 export * from './viemToEthersAdapters';
 export * from './uniswapPermitSigning';
 export * from './firstAndLast';
+export * from './getIconFromSymbol';


### PR DESCRIPTION
- Displays the 5 latest swaps from the subgraph.
- The component was based on Recent Shifts.
- Base and BNB does not return a value from the API, seems like not a frontend issue.
- Works on all browsers, works on mobile.
- Could not get msw to mock loading/error states in Storybook.
- We could later add links to explorers.

![image](https://github.com/sifiorg/sifi/assets/128667801/636c85ce-34fb-4034-85c1-a3b62fbaffe6)
![image](https://github.com/sifiorg/sifi/assets/128667801/7056c528-cecb-4cbf-ae97-24be0f436722)

Closes #357 