### PR TITLE
feat(frontend): simplify copy and layout

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -10,11 +10,11 @@
     <title>Sifi - On-chain Swap</title>
     <meta
       name="description"
-      content="Swap from anything to anything in a single transaction, we'll find the best route. It's Sifi."
+      content="A futuristic swap machine. Sifi.org allows users to trade assets cross-chain, in a single transaction."
     />
     <meta
       property="og:description"
-      content="Swap from anything to anything in a single transaction, we'll find the best route. It's Sifi."
+      content="A futuristic swap machine. Sifi.org allows users to trade assets cross-chain, in a single transaction."
     />
     <script>
       window.global = window;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -23,7 +23,7 @@ const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
 const Home: FunctionComponent = () => {
   return (
     <>
-      <div className="mt-12 flex min-h-[90vh] flex-col md:mt-0 md:justify-center">
+      <div className="flex min-h-[90vh] flex-col md:justify-center">
         <Hero />
         <RecentWarps />
       </div>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import { Header } from './components/Header/Header';
 import { Hero } from './components/Hero/Hero';
 import { Route, Routes } from 'react-router-dom';
 import { SpaceTravelCanvas } from './space-travel/SpaceTravelCanvas';
-import { Stats } from './components/Stats/Stats';
 import { RecentWarps } from './components/RecentWarps/RecentWarps';
 
 const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
@@ -14,7 +13,6 @@ const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
       <SpaceTravelCanvas />
       <div className="relative">
         <Header />
-        <Stats />
         <main className="px-2 sm:px-8 relative">{children}</main>
         <Footer />
       </div>

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -210,7 +210,7 @@ const CreateSwap = () => {
       <div className="bg-white pb-8 shadow sm:rounded-lg">
         <form className="space-y-6" onSubmit={handleSubmit(executeSwap)}>
           <div>
-            <div className="py-4">
+            <div className="sm:py-4">
               <div className="mb-2">
                 <div className="flex justify-between align-bottom items-end">
                   <div className="font-display text-smoke">{ShiftInputLabel.from}</div>

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -210,7 +210,7 @@ const CreateSwap = () => {
       <div className="bg-white pb-4 shadow sm:rounded-lg">
         <form className="space-y-6" onSubmit={handleSubmit(executeSwap)}>
           <div>
-            <div className="sm:py-4">
+            <div className="sm:py-2">
               <div className="mb-2">
                 <div className="flex justify-between align-bottom items-end">
                   <div className="font-display text-smoke">{ShiftInputLabel.from}</div>

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -210,7 +210,7 @@ const CreateSwap = () => {
       <div className="bg-white pb-4 shadow sm:rounded-lg">
         <form className="space-y-6" onSubmit={handleSubmit(executeSwap)}>
           <div>
-            <div className="sm:py-2">
+            <div className="pb-2">
               <div className="mb-2">
                 <div className="flex justify-between align-bottom items-end">
                   <div className="font-display text-smoke">{ShiftInputLabel.from}</div>

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -206,8 +206,8 @@ const CreateSwap = () => {
   }, [fromToken]);
 
   return (
-    <div className="m:w-full py-2 sm:max-w-md">
-      <div className="bg-white pb-8 shadow sm:rounded-lg">
+    <div className="m:w-full pt-2 sm:max-w-md">
+      <div className="bg-white pb-4 shadow sm:rounded-lg">
         <form className="space-y-6" onSubmit={handleSubmit(executeSwap)}>
           <div>
             <div className="sm:py-4">

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -206,7 +206,7 @@ const CreateSwap = () => {
   }, [fromToken]);
 
   return (
-    <div className="m:w-full pt-2 sm:max-w-md">
+    <div className="m:w-full sm:max-w-md">
       <div className="bg-white pb-4 shadow sm:rounded-lg">
         <form className="space-y-6" onSubmit={handleSubmit(executeSwap)}>
           <div>

--- a/packages/frontend/src/components/Footer/Footer.tsx
+++ b/packages/frontend/src/components/Footer/Footer.tsx
@@ -4,11 +4,28 @@ import { ReactComponent as Logo } from '../../assets/logoWhite.svg';
 import { texts } from 'src/texts';
 
 const Footer: FunctionComponent = () => {
+  const columnLinks = [
+    [
+      {
+        href: 'https://docs.sifi.org',
+        title: 'Docs',
+        external: true,
+      },
+    ],
+    [
+      {
+        href: 'https://discord.gg/sXDKcUYnU8',
+        title: 'Discord',
+        external: true,
+      },
+    ],
+  ];
+
   return (
     <FooterComponent
       Logo={Logo}
       description={texts.DESCRIPTION}
-      columnLinks={[]}
+      columnLinks={columnLinks}
       name={texts.NAME}
       socialLinks={{ discord: new URL('https://discord.gg/sXDKcUYnU8') }}
       bottomLinks={[]}

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -6,10 +6,12 @@ import { HeaderChainSelector } from '../HeaderChainSelector/HeaderChainSelector'
 
 const Header: FunctionComponent = () => {
   return (
-    <Navbar logo={logo}>
-      <HeaderChainSelector />
-      <HeaderMenu />
-    </Navbar>
+    <>
+      <Navbar logo={logo}>
+        <HeaderChainSelector />
+        <HeaderMenu />
+      </Navbar>
+    </>
   );
 };
 

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -5,21 +5,8 @@ import HeaderMenu from '../HeaderMenu/HeaderMenu';
 import { HeaderChainSelector } from '../HeaderChainSelector/HeaderChainSelector';
 
 const Header: FunctionComponent = () => {
-  const navLinks = [
-    {
-      href: 'https://discord.gg/sXDKcUYnU8',
-      title: 'Discord',
-      external: true,
-    },
-    {
-      href: 'https://docs.sifi.org',
-      title: 'Docs',
-      external: true,
-    },
-  ];
-
   return (
-    <Navbar logo={logo} navLinks={navLinks}>
+    <Navbar logo={logo}>
       <HeaderChainSelector />
       <HeaderMenu />
     </Navbar>

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -9,7 +9,7 @@ const Hero = () => (
         Swap
       </h1>
       <Stats />
-      <div className="border-darker-gray mx-auto max-w-[27rem] border-b-[1px]">
+      <div className="border-darker-gray mx-auto max-w-[27rem] border-b-[1px] pb-2">
         <CreateSwap />
       </div>
       <p className="text-smoke font-text mx-auto text-center text-base font-light md:max-w-[380px] pt-6">

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -1,18 +1,14 @@
-import { texts } from 'src/texts';
 import { CreateSwap } from '../CreateSwap/CreateSwap';
 
 const Hero = () => (
   <div className="mx-auto flex w-full max-w-[67rem] flex-wrap justify-center px-4 py-4 sm:px-8 lg:px-16">
     <div className="w-full flex-col items-center justify-center md:w-[50%] md:pb-16">
       <h1 className="text-flashbang-white font-display mb-4 text-center text-[1.875rem] sm:text-[2.25rem]">
-        {texts.TITLE}
+        Swap
       </h1>
-      <div className="border-darker-gray mx-auto mb-4 max-w-[27rem] border-b-[1px]">
+      <div className="mx-auto mb-4 max-w-[27rem]">
         <CreateSwap />
       </div>
-      <p className="text-smoke font-text mx-auto text-left text-base font-light md:max-w-[380px]">
-        {texts.DESCRIPTION}
-      </p>
     </div>
   </div>
 );

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -1,14 +1,20 @@
+import { texts } from 'src/texts';
 import { CreateSwap } from '../CreateSwap/CreateSwap';
+import { Stats } from '../Stats/Stats';
 
 const Hero = () => (
-  <div className="mx-auto flex w-full max-w-[67rem] min-h-[90vh] flex-wrap justify-center items-center px-4 py-4 sm:px-8 lg:px-16">
+  <div className="mx-auto flex w-full max-w-[67rem] min-h-[90vh] flex-wrap justify-center items-center px-4 py-4 sm:px-8 lg:px-16 ">
     <div className="w-full md:w-[50%] relative top-[-5vh]">
       <h1 className="text-flashbang-white font-display mb-0 pb-0 text-center text-[1.875rem] sm:text-[2.25rem]">
         Swap
       </h1>
-      <div className="mx-auto max-w-[27rem]">
+      <Stats />
+      <div className="border-darker-gray mx-auto max-w-[27rem] border-b-[1px]">
         <CreateSwap />
       </div>
+      <p className="text-smoke font-text mx-auto text-center text-base font-light md:max-w-[380px] pt-6">
+        {texts.DESCRIPTION}
+      </p>
     </div>
   </div>
 );

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -8,13 +8,15 @@ const Hero = () => (
       <h1 className="text-flashbang-white font-display mb-0 pb-0 text-center text-[1.875rem] sm:text-[2.25rem]">
         Swap
       </h1>
-      <Stats />
       <div className="border-darker-gray mx-auto max-w-[27rem] border-b-[1px] pb-2">
         <CreateSwap />
       </div>
-      <p className="text-smoke font-text mx-auto text-center text-base font-light md:max-w-[380px] pt-6">
+      <p className="text-smoke font-text mx-auto text-center text-base font-light md:max-w-[380px] pt-6 pb-6">
         {texts.DESCRIPTION}
       </p>
+      <div className="mx-auto max-w-[27rem] ">
+        <Stats />
+      </div>
     </div>
   </div>
 );

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -1,12 +1,12 @@
 import { CreateSwap } from '../CreateSwap/CreateSwap';
 
 const Hero = () => (
-  <div className="mx-auto flex w-full max-w-[67rem] flex-wrap justify-center px-4 py-4 sm:px-8 lg:px-16">
-    <div className="w-full flex-col items-center justify-center md:w-[50%] md:pb-16">
-      <h1 className="text-flashbang-white font-display mb-4 text-center text-[1.875rem] sm:text-[2.25rem]">
+  <div className="mx-auto flex w-full max-w-[67rem] min-h-[90vh] flex-wrap justify-center items-center px-4 py-4 sm:px-8 lg:px-16">
+    <div className="w-full md:w-[50%] relative top-[-5vh]">
+      <h1 className="text-flashbang-white font-display mb-0 pb-0 text-center text-[1.875rem] sm:text-[2.25rem]">
         Swap
       </h1>
-      <div className="mx-auto mb-4 max-w-[27rem]">
+      <div className="mx-auto max-w-[27rem]">
         <CreateSwap />
       </div>
     </div>

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -1,9 +1,9 @@
 import { Table, formatTokenAmount, Skeleton } from '@sifi/shared-ui';
 import { FunctionComponent } from 'react';
 import { useRecentWarps } from 'src/hooks/useRecentWarps';
-import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { useTokens } from 'src/hooks/useTokens';
 import { getIconFromSymbol } from 'src/utils';
+import { Stats } from '../Stats/Stats';
 
 const RecentWarpsTableData: FunctionComponent = () => {
   const { data: warps, error, isLoading } = useRecentWarps();
@@ -95,13 +95,13 @@ const RecentWarpsTableData: FunctionComponent = () => {
 };
 
 const RecentWarps: FunctionComponent = () => {
-  const { fromChain } = useSwapFormValues();
   return (
     <section>
       <div className="mx-auto w-full max-w-2xl py-16">
-        <div className="flex flex-col items-center justify-between gap-8">
-          <h2 className="mb-4 text-center text-3xl sm:mb-8">Recent Swaps from {fromChain.name}</h2>
-          <div className="dark:border-darker-gray border-smoke w-full border-t">
+        <div className="flex flex-col items-center justify-between gap-2">
+          <h2 className="text-center text-3xl">Recent</h2>
+          <Stats />
+          <div className="dark:border-darker-gray border-smoke w-full border-t mt-4">
             <Table>
               <thead>
                 <Table.Row>

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -100,7 +100,6 @@ const RecentWarps: FunctionComponent = () => {
       <div className="mx-auto w-full max-w-2xl py-16">
         <div className="flex flex-col items-center justify-between gap-2">
           <h2 className="text-center text-3xl">Recent</h2>
-          <Stats />
           <div className="dark:border-darker-gray border-smoke w-full border-t mt-4">
             <Table>
               <thead>

--- a/packages/frontend/src/components/Stats/Stats.tsx
+++ b/packages/frontend/src/components/Stats/Stats.tsx
@@ -9,7 +9,7 @@ const Stats = () => {
   }
 
   return (
-    <div className="font-display m-auto text-center text-sm p-1 pb-0 flex place-items-center justify-center relative">
+    <div className="m-auto font-text text-center pb-2 flex place-items-center justify-center relative text-smoke">
       {data ? (
         `All-time volume: $${numberWithCommas(data)}`
       ) : (

--- a/packages/frontend/src/components/Stats/Stats.tsx
+++ b/packages/frontend/src/components/Stats/Stats.tsx
@@ -9,7 +9,7 @@ const Stats = () => {
   }
 
   return (
-    <div className="m-auto font-text text-center pb-2 flex place-items-center justify-center relative text-smoke">
+    <div className="m-auto font-text text-center flex place-items-center justify-center relative text-smoke font-light">
       {data ? (
         `All-time volume: $${numberWithCommas(data)}`
       ) : (

--- a/packages/frontend/src/components/Stats/Stats.tsx
+++ b/packages/frontend/src/components/Stats/Stats.tsx
@@ -9,7 +9,7 @@ const Stats = () => {
   }
 
   return (
-    <div className="font-display m-auto text-center text-sm p-2 flex place-items-center justify-center relative">
+    <div className="font-display m-auto text-center text-sm p-1 pb-0 flex place-items-center justify-center relative">
       {data ? (
         `All-time volume: $${numberWithCommas(data)}`
       ) : (

--- a/packages/frontend/src/texts.ts
+++ b/packages/frontend/src/texts.ts
@@ -2,8 +2,7 @@ const texts = {
   // index.html has to be manually updated
   NAME: 'Sifi',
   TITLE: 'On-Chain Swap',
-  DESCRIPTION:
-    "Swap from anything to anything in a single transaction. We'll find the best route. It's Sifi.",
+  DESCRIPTION: 'A futuristic swap machine. Trade assets cross-chain, in a single transaction.',
 };
 
 export { texts };


### PR DESCRIPTION
- Based on https://discord.com/channels/1032578356241244160/1037692726059225131/1169232140462989362
- Remove links from the top nav, place them in the footer instead
- Shorten titles, "Swap" and "Recent"
- Replace description based on https://discord.com/channels/1032578356241244160/1037692726059225131/1169234680592220170
- Move All-Time Volume under the paragraph, tone down it's styling.
- Always center CreateSwap - looks best with the warp animation. Ensure that other sections don't distract users on any screen sizes

![image](https://github.com/sifiorg/sifi/assets/128667801/4b7d9b5f-781b-4c1c-a26d-62caf381fa32)
![image](https://github.com/sifiorg/sifi/assets/128667801/8bd25588-af94-40e0-854a-641bd63e8ee2)






