### PR TITLE
feat(frontend): show recent swaps across all chains

### DIFF
--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import { useRecentWarps } from 'src/hooks/useRecentWarps';
 import { useTokens } from 'src/hooks/useTokens';
 import { getIconFromSymbol } from 'src/utils';
-import { Stats } from '../Stats/Stats';
+import { getChainIcon } from 'src/utils/chains';
 
 const RecentWarpsTableData: FunctionComponent = () => {
   const { data: warps, error, isLoading } = useRecentWarps();
@@ -45,11 +45,17 @@ const RecentWarpsTableData: FunctionComponent = () => {
                     From
                   </span>
                   <div className="flex items-center">
-                    <img
-                      className="mr-3 h-6 w-6 rounded-full"
-                      src={getIconFromSymbol(warp.tokenIn.symbol, fromTokens)}
-                      alt="Logo"
-                    />
+                    <div className="relative mr-3 ">
+                      <img
+                        className="h-6 w-6 rounded-full"
+                        src={getIconFromSymbol(warp.tokenIn.symbol, fromTokens)}
+                        alt="Logo"
+                      />
+                      <img
+                        src={getChainIcon(warp.chainId)}
+                        className="w-3 h-3 -right-1 -bottom-1 absolute"
+                      />
+                    </div>
                     <span>{`${formatTokenAmount(warp.amountInDecimal)} ${
                       warp.tokenIn.symbol
                     }`}</span>
@@ -75,11 +81,17 @@ const RecentWarpsTableData: FunctionComponent = () => {
                     To
                   </span>
                   <div className="flex items-center sm:pl-8">
-                    <img
-                      className="mr-3 h-6 w-6 rounded-full"
-                      src={getIconFromSymbol(warp.tokenOut.symbol, fromTokens)}
-                      alt="Logo"
-                    />
+                    <div className="relative mr-3 ">
+                      <img
+                        className="h-6 w-6 rounded-full"
+                        src={getIconFromSymbol(warp.tokenOut.symbol, fromTokens)}
+                        alt="Logo"
+                      />
+                      <img
+                        src={getChainIcon(warp.chainId)}
+                        className="w-3 h-3 -right-1 -bottom-1 absolute"
+                      />
+                    </div>
                     <span>{`${formatTokenAmount(warp.amountOutDecimal)} ${
                       warp.tokenOut.symbol
                     }`}</span>

--- a/packages/frontend/src/hooks/useRecentWarps.tsx
+++ b/packages/frontend/src/hooks/useRecentWarps.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { request, gql } from 'graphql-request';
 import GRAPH_URLS from 'src/subgraph.json';
-import { useSwapFormValues } from './useSwapFormValues';
+import { SUPPORTED_CHAINS } from 'src/utils/chains';
 
 const RECENT_WARPS_QUERY = gql`
   query recentWarps($since: BigInt!) {
@@ -22,6 +22,7 @@ const RECENT_WARPS_QUERY = gql`
 
 type Warp = {
   addedAt: string;
+  chainId: number;
   amountInDecimal: string;
   tokenIn: {
     symbol: string;
@@ -41,16 +42,39 @@ type GraphUrls = {
   [key: string]: string;
 };
 
+const getRecentWarpsForChainId = async (chainId: number): Promise<Warp[]> => {
+  const url = (GRAPH_URLS as GraphUrls)[chainId.toString()];
+
+  if (!url) return [];
+
+  const response: RecentWarpsResponse = await request(url, RECENT_WARPS_QUERY, { since: '0' });
+
+  return response.warps.map(warp => ({ ...warp, chainId })) as Warp[];
+};
+
 const useRecentWarps = () => {
-  const { fromChain } = useSwapFormValues();
-
   return useQuery(
-    ['recentWarps', fromChain.id.toString()],
+    ['recentWarps'],
     async () => {
-      const url = (GRAPH_URLS as GraphUrls)[fromChain.id];
-      const response: RecentWarpsResponse = await request(url, RECENT_WARPS_QUERY, { since: '0' });
+      const responses = await Promise.allSettled(
+        SUPPORTED_CHAINS.map(({ id }) => getRecentWarpsForChainId(id))
+      );
 
-      return response.warps as Warp[];
+      return responses
+        .map(response => {
+          if (
+            response.status === 'fulfilled' &&
+            (response satisfies PromiseFulfilledResult<Warp[]>) &&
+            response.value?.length
+          ) {
+            return response.value;
+          }
+
+          return [];
+        })
+        .flat()
+        .sort((a, b) => (Number(a.addedAt) < Number(b.addedAt) ? 1 : -1))
+        .slice(0, 10);
     },
     {
       staleTime: 1000 * 60 * 5, // 5 minutes


### PR DESCRIPTION
### Changes Made

- Fetch swaps for all supported chains, and show them in the RecentSwaps Component

### Screenshots/videos

<img width="1512" alt="Screenshot 2023-11-02 at 11 36 46" src="https://github.com/sifiorg/sifi/assets/128688932/292cc011-a08b-4683-b709-ea00c8fad114">

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #386 
