### PR TITLE
feat(frontend): replace avax explorer link

### DIFF
--- a/packages/frontend/src/utils/chains.ts
+++ b/packages/frontend/src/utils/chains.ts
@@ -24,7 +24,19 @@ const PRODUCTION_CHAINS: Chain[] = [
   // The order in which the chains are displayed in the UI
   mainnet,
   arbitrum,
-  avalanche,
+  {
+    ...avalanche,
+    blockExplorers: {
+      etherscan: {
+          name: "Avascan",
+          url: "https://avascan.info/blockchain/c",
+      },
+      default: {
+          name: "Avascan",
+          url: "https://avascan.info/blockchain/c",
+      },
+  },
+  },
   base,
   {
     ...bsc,


### PR DESCRIPTION
 - Replace default Snowtrace explorer link for AVAX with Avascan, prior to deprecation
 - Tested with https://github.com/sifiorg/sifi/pull/393, transaction is correctly linked to for AVAX :heavy_check_mark: 