### PR TITLE
feat(frontend): add partner dashboard

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Hero } from './components/Hero/Hero';
 import { Route, Routes } from 'react-router-dom';
 import { SpaceTravelCanvas } from './space-travel/SpaceTravelCanvas';
 import { RecentWarps } from './components/RecentWarps/RecentWarps';
+import { Dashboard } from 'src/pages/Dashboard';
 
 const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
   return (
@@ -39,6 +40,7 @@ const App = () => {
           <Route path="/:ref" element={<Home />} />
           <Route path="/:fromToken/:toToken" element={<Home />} />
           <Route path="/:fromToken/:toToken/:ref" element={<Home />} />
+          <Route path="/dashboard" element={<Dashboard />} />
           <Route path="*" element={<Home />} />
         </Routes>
       </Layout>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,7 +13,9 @@ const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
       <SpaceTravelCanvas />
       <div className="relative">
         <Header />
-        <main className="px-2 sm:px-8 relative">{children}</main>
+        <main className="px-2 sm:px-8 relative flex min-h-[90vh] flex-col md:justify-center">
+          {children}
+        </main>
         <Footer />
       </div>
     </>
@@ -23,10 +25,8 @@ const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
 const Home: FunctionComponent = () => {
   return (
     <>
-      <div className="flex min-h-[90vh] flex-col md:justify-center">
-        <Hero />
-        <RecentWarps />
-      </div>
+      <Hero />
+      <RecentWarps />
     </>
   );
 };

--- a/packages/frontend/src/components/Footer/Footer.tsx
+++ b/packages/frontend/src/components/Footer/Footer.tsx
@@ -7,6 +7,10 @@ const Footer: FunctionComponent = () => {
   const columnLinks = [
     [
       {
+        title: 'Dashboard',
+        href: '/dashboard',
+      },
+      {
         href: 'https://docs.sifi.org',
         title: 'Docs',
         external: true,

--- a/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
+++ b/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
@@ -2,7 +2,6 @@ import { FunctionComponent } from 'react';
 import { Menu, useWalletBranding } from '@sifi/shared-ui';
 import { useAccount, useDisconnect, useEnsName, useNetwork } from 'wagmi';
 import { formatAddress, formatEnsName } from 'src/utils';
-import { useNavigate } from 'react-router-dom';
 
 const HeaderMenu: FunctionComponent = () => {
   const { address, isConnected } = useAccount();
@@ -11,8 +10,6 @@ const HeaderMenu: FunctionComponent = () => {
   const { disconnect } = useDisconnect();
   const { icon, text } = useWalletBranding();
 
-  const navigate = useNavigate();
-
   if (!address || !isConnected) return null;
 
   const label = ensName ? formatEnsName(ensName) : formatAddress(address);
@@ -20,7 +17,7 @@ const HeaderMenu: FunctionComponent = () => {
   const menuLinks = [
     {
       title: 'Dashboard',
-      onClick: () => navigate('/dashboard'),
+      href: '/dashboard',
     },
     {
       title: 'Disconnect Wallet',

--- a/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
+++ b/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'react';
 import { Menu, useWalletBranding } from '@sifi/shared-ui';
 import { useAccount, useDisconnect, useEnsName, useNetwork } from 'wagmi';
 import { formatAddress, formatEnsName } from 'src/utils';
+import { useNavigate } from 'react-router-dom';
 
 const HeaderMenu: FunctionComponent = () => {
   const { address, isConnected } = useAccount();
@@ -10,11 +11,17 @@ const HeaderMenu: FunctionComponent = () => {
   const { disconnect } = useDisconnect();
   const { icon, text } = useWalletBranding();
 
+  const navigate = useNavigate();
+
   if (!address || !isConnected) return null;
 
   const label = ensName ? formatEnsName(ensName) : formatAddress(address);
 
   const menuLinks = [
+    {
+      title: 'Dashboard',
+      onClick: () => navigate('/dashboard'),
+    },
     {
       title: 'Disconnect Wallet',
       onClick: () => disconnect(),
@@ -22,7 +29,11 @@ const HeaderMenu: FunctionComponent = () => {
   ];
 
   return (
-    <Menu icon={icon ? { src: icon, alt: `${text} icon`} : undefined} label={label} links={menuLinks}>
+    <Menu
+      icon={icon ? { src: icon, alt: `${text} icon` } : undefined}
+      label={label}
+      links={menuLinks}
+    >
       <div className="px-6 py-4">
         <span className="mb-3 block text-sm" id="network-label">
           Network

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -18,6 +18,8 @@ const ERC20_ABI = [
 // Based on various interactions with the Sifi Smart Contract
 const SWAP_MAX_GAS_UNITS = 150000;
 
+const SIFI_CONTRACT_ADDRESS = '0x65c49E9996A877d062085B71E1460fFBe3C4c5Aa';
+
 export {
   ETH_CONTRACT_ADDRESS,
   MIN_ALLOWANCE,

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -20,6 +20,60 @@ const SWAP_MAX_GAS_UNITS = 150000;
 
 const SIFI_CONTRACT_ADDRESS = '0x65c49E9996A877d062085B71E1460fFBe3C4c5Aa';
 
+const STAR_VAULT_ABI = [
+  { inputs: [], name: 'EthTransferFailed', type: 'error' },
+  {
+    inputs: [{ internalType: 'uint256', name: 'available', type: 'uint256' }],
+    name: 'InsufficientOwnerBalance',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'address', name: 'partner', type: 'address' },
+      { indexed: true, internalType: 'address', name: 'token', type: 'address' },
+      { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    name: 'PartnerWithdraw',
+    type: 'event',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'token', type: 'address' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'address payable', name: 'to', type: 'address' },
+    ],
+    name: 'ownerWithdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'partner', type: 'address' },
+      { internalType: 'address', name: 'token', type: 'address' },
+    ],
+    name: 'partnerTokenBalance',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'partner', type: 'address' }],
+    name: 'partnerTokens',
+    outputs: [{ internalType: 'address[]', name: 'tokens_', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'token', type: 'address' }],
+    name: 'partnerWithdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];
+
 export {
   ETH_CONTRACT_ADDRESS,
   MIN_ALLOWANCE,
@@ -27,4 +81,6 @@ export {
   POPULAR_TOKEN_SYMBOLS,
   SWAP_MAX_GAS_UNITS,
   ERC20_ABI,
+  SIFI_CONTRACT_ADDRESS,
+  STAR_VAULT_ABI,
 };

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -1,4 +1,5 @@
 const ETH_CONTRACT_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+const ETH_ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_ALLOWANCE = '0xffffffffffffffffffffffffffffff';
 const MAX_ALLOWANCE = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 const POPULAR_TOKEN_SYMBOLS = ['ETH', 'USDT', 'XAI', 'USDC', 'WBTC', 'BUSD', 'DAI'];
@@ -76,6 +77,7 @@ const STAR_VAULT_ABI = [
 
 export {
   ETH_CONTRACT_ADDRESS,
+  ETH_ZERO_ADDRESS,
   MIN_ALLOWANCE,
   MAX_ALLOWANCE,
   POPULAR_TOKEN_SYMBOLS,

--- a/packages/frontend/src/hooks/useFetchTokens.tsx
+++ b/packages/frontend/src/hooks/useFetchTokens.tsx
@@ -1,13 +1,15 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { showToast } from '@sifi/shared-ui';
 import { getOrderedTokenList } from 'src/utils/tokens';
 import { useSifi } from 'src/providers/SDKProvider';
-import { useEffect, useState } from 'react';
 import { Token } from '@sifi/sdk';
 
 const useFetchTokens = (chainIds: number[]) => {
   const sifi = useSifi();
-  const [tokensByAddress, setTokensByAddress] = useState<Record<string, Token>>({});
+  const [tokensByChainIdAndAddress, setTokensByChainIdAndAddress] = useState<Record<string, Token>>(
+    {}
+  );
 
   const { data, refetch } = useQuery(
     ['tokens', chainIds],
@@ -28,10 +30,12 @@ const useFetchTokens = (chainIds: number[]) => {
       const { data: tokensData } = await refetch();
       if (tokensData) {
         const lookup = tokensData.reduce<Record<string, Token>>((acc, token) => {
-          acc[token.address.toLowerCase()] = token;
+          const key = `${token.chainId}-${token.address.toLowerCase()}`;
+          acc[key] = token;
+
           return acc;
         }, {});
-        setTokensByAddress(lookup);
+        setTokensByChainIdAndAddress(lookup);
 
         return tokensData;
       }
@@ -44,7 +48,7 @@ const useFetchTokens = (chainIds: number[]) => {
     return [];
   };
 
-  return { fetchTokens, data, tokensByAddress };
+  return { fetchTokens, data, tokensByChainIdAndAddress };
 };
 
 export { useFetchTokens };

--- a/packages/frontend/src/hooks/useFetchTokens.tsx
+++ b/packages/frontend/src/hooks/useFetchTokens.tsx
@@ -2,9 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { showToast } from '@sifi/shared-ui';
 import { getOrderedTokenList } from 'src/utils/tokens';
 import { useSifi } from 'src/providers/SDKProvider';
+import { useEffect, useState } from 'react';
+import { Token } from '@sifi/sdk';
 
 const useFetchTokens = (chainIds: number[]) => {
   const sifi = useSifi();
+  const [tokensByAddress, setTokensByAddress] = useState<Record<string, Token>>({});
 
   const { data, refetch } = useQuery(
     ['tokens', chainIds],
@@ -24,6 +27,12 @@ const useFetchTokens = (chainIds: number[]) => {
     try {
       const { data: tokensData } = await refetch();
       if (tokensData) {
+        const lookup = tokensData.reduce<Record<string, Token>>((acc, token) => {
+          acc[token.address.toLowerCase()] = token;
+          return acc;
+        }, {});
+        setTokensByAddress(lookup);
+
         return tokensData;
       }
     } catch (error) {
@@ -35,7 +44,7 @@ const useFetchTokens = (chainIds: number[]) => {
     return [];
   };
 
-  return { fetchTokens, data };
+  return { fetchTokens, data, tokensByAddress };
 };
 
 export { useFetchTokens };

--- a/packages/frontend/src/hooks/usePartnerData.tsx
+++ b/packages/frontend/src/hooks/usePartnerData.tsx
@@ -1,0 +1,41 @@
+import { PartnerTokens, usePartnerTokens } from './usePartnerTokens';
+
+const calculateTotalBalanceUsd = (partnerTokens: PartnerTokens) => {
+  return partnerTokens
+    ? Object.values(partnerTokens).reduce((total, data) => {
+        if (data?.partner?.tokens) {
+          const totalForChain = data.partner.tokens.reduce(
+            (total, token) => total + parseFloat(token.balanceUsd),
+            0
+          );
+          return total + totalForChain;
+        }
+        return parseFloat(total.toFixed(2));
+      }, 0)
+    : 0;
+};
+
+const calculateLifetimeEarningsUsd = (partnerTokens: PartnerTokens) => {
+  return partnerTokens
+    ? Object.values(partnerTokens).reduce((total, data) => {
+        if (data?.partner?.tokens) {
+          const totalForChain = data.partner.tokens.reduce(
+            (total, token) => total + parseFloat(token.balanceUsd) + parseFloat(token.withdrawnUsd),
+            0
+          );
+          return total + totalForChain;
+        }
+        return parseFloat(total.toFixed(2));
+      }, 0)
+    : 0;
+};
+
+const usePartnerData = (address: string) => {
+  const { data: partnerTokens, isLoading } = usePartnerTokens(address || '');
+  const totalBalanceUsd = partnerTokens ? calculateTotalBalanceUsd(partnerTokens) : 0;
+  const lifetimeEarningsUsd = partnerTokens ? calculateLifetimeEarningsUsd(partnerTokens) : 0;
+
+  return { partnerTokens, totalBalanceUsd, lifetimeEarningsUsd, isLoading };
+};
+
+export { usePartnerData };

--- a/packages/frontend/src/hooks/usePartnerData.tsx
+++ b/packages/frontend/src/hooks/usePartnerData.tsx
@@ -1,8 +1,8 @@
-import { PartnerTokens, usePartnerTokens } from './usePartnerTokens';
+import { PartnerTokensByChain, usePartnerTokens } from './usePartnerTokens';
 
-const calculateTotalBalanceUsd = (partnerTokens: PartnerTokens) => {
-  return partnerTokens
-    ? Object.values(partnerTokens).reduce((total, data) => {
+const calculateTotalBalanceUsd = (partnerTokensByChain: PartnerTokensByChain) => {
+  return partnerTokensByChain
+    ? Object.values(partnerTokensByChain).reduce((total, data) => {
         if (data?.partner?.tokens) {
           const totalForChain = data.partner.tokens.reduce(
             (total, token) => total + parseFloat(token.balanceUsd),
@@ -15,9 +15,9 @@ const calculateTotalBalanceUsd = (partnerTokens: PartnerTokens) => {
     : 0;
 };
 
-const calculateLifetimeEarningsUsd = (partnerTokens: PartnerTokens) => {
-  return partnerTokens
-    ? Object.values(partnerTokens).reduce((total, data) => {
+const calculateLifetimeEarningsUsd = (partnerTokensByChain: PartnerTokensByChain) => {
+  return partnerTokensByChain
+    ? Object.values(partnerTokensByChain).reduce((total, data) => {
         if (data?.partner?.tokens) {
           const totalForChain = data.partner.tokens.reduce(
             (total, token) => total + parseFloat(token.balanceUsd) + parseFloat(token.withdrawnUsd),
@@ -31,11 +31,13 @@ const calculateLifetimeEarningsUsd = (partnerTokens: PartnerTokens) => {
 };
 
 const usePartnerData = (address: string) => {
-  const { data: partnerTokens, isLoading } = usePartnerTokens(address || '');
-  const totalBalanceUsd = partnerTokens ? calculateTotalBalanceUsd(partnerTokens) : 0;
-  const lifetimeEarningsUsd = partnerTokens ? calculateLifetimeEarningsUsd(partnerTokens) : 0;
+  const { data: partnerTokensByChain, isLoading } = usePartnerTokens(address || '');
+  const totalBalanceUsd = partnerTokensByChain ? calculateTotalBalanceUsd(partnerTokensByChain) : 0;
+  const lifetimeEarningsUsd = partnerTokensByChain
+    ? calculateLifetimeEarningsUsd(partnerTokensByChain)
+    : 0;
 
-  return { partnerTokens, totalBalanceUsd, lifetimeEarningsUsd, isLoading };
+  return { partnerTokensByChain, totalBalanceUsd, lifetimeEarningsUsd, isLoading };
 };
 
 export { usePartnerData };

--- a/packages/frontend/src/hooks/usePartnerTokens.tsx
+++ b/packages/frontend/src/hooks/usePartnerTokens.tsx
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query';
+import { request, gql } from 'graphql-request';
+import GRAPH_URLS from 'src/subgraph.json';
+
+const PARTNER_TOKENS_QUERY = gql`
+  query GetPartnerTokens($id: ID!) {
+    partner(id: $id) {
+      id
+      tokens {
+        id
+        balance
+        balanceDecimal
+        balanceUsd
+        withdrawn
+        withdrawnDecimal
+        withdrawnUsd
+        modifiedAt
+        modifiedAtBlock
+        modifiedAtTransaction
+      }
+    }
+  }
+`;
+
+type PartnerTokensResponse = {
+  partner: {
+    id: string;
+    tokens: Array<{
+      id: string;
+      balance: string;
+      balanceDecimal: string;
+      balanceUsd: string;
+      withdrawn: string;
+      withdrawnDecimal: string;
+      withdrawnUsd: string;
+      modifiedAt: string;
+      modifiedAtBlock: string;
+      modifiedAtTransaction: string;
+    }>;
+  };
+};
+
+type PartnerTokens = Record<string, PartnerTokensResponse | null>;
+
+const usePartnerTokens = (address: string) => {
+  return useQuery(
+    ['partnerTokens', address],
+    async () => {
+      const responses = await Promise.all(
+        Object.entries(GRAPH_URLS).map(([chainId, url]) =>
+          request(url, PARTNER_TOKENS_QUERY, { id: address.toLocaleLowerCase() })
+            .then<PartnerTokensResponse>()
+            .catch((error: any) => {
+              console.error(`Failed to fetch data for ${chainId}:`, error);
+
+              return null;
+            })
+        )
+      );
+
+      const result: Record<string, PartnerTokensResponse | null> = {};
+      Object.keys(GRAPH_URLS).forEach((chainId, index) => {
+        result[chainId] = responses[index];
+      });
+
+      return result;
+    },
+
+    {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: false,
+      refetchInterval: 15000, // 15 seconds
+    }
+  );
+};
+
+export { usePartnerTokens };
+export type { PartnerTokens };

--- a/packages/frontend/src/hooks/usePartnerTokens.tsx
+++ b/packages/frontend/src/hooks/usePartnerTokens.tsx
@@ -22,29 +22,31 @@ const PARTNER_TOKENS_QUERY = gql`
   }
 `;
 
+type TokenOfPartner = {
+  id: string;
+  balance: string;
+  balanceDecimal: string;
+  balanceUsd: string;
+  withdrawn: string;
+  withdrawnDecimal: string;
+  withdrawnUsd: string;
+  modifiedAt: string;
+  modifiedAtBlock: string;
+  modifiedAtTransaction: string;
+};
+
 type PartnerTokensResponse = {
   partner: {
     id: string;
-    tokens: Array<{
-      id: string;
-      balance: string;
-      balanceDecimal: string;
-      balanceUsd: string;
-      withdrawn: string;
-      withdrawnDecimal: string;
-      withdrawnUsd: string;
-      modifiedAt: string;
-      modifiedAtBlock: string;
-      modifiedAtTransaction: string;
-    }>;
+    tokens: Array<TokenOfPartner>;
   };
 };
 
-type PartnerTokens = Record<string, PartnerTokensResponse | null>;
+type PartnerTokensByChain = Record<string, PartnerTokensResponse | null>;
 
 const usePartnerTokens = (address: string) => {
   return useQuery(
-    ['partnerTokens', address],
+    ['partnerTokensByChain', address],
     async () => {
       const responses = await Promise.all(
         Object.entries(GRAPH_URLS).map(([chainId, url]) =>
@@ -75,4 +77,4 @@ const usePartnerTokens = (address: string) => {
 };
 
 export { usePartnerTokens };
-export type { PartnerTokens };
+export type { PartnerTokensByChain, TokenOfPartner };

--- a/packages/frontend/src/hooks/usePartnerTokens.tsx
+++ b/packages/frontend/src/hooks/usePartnerTokens.tsx
@@ -11,12 +11,15 @@ const PARTNER_TOKENS_QUERY = gql`
         balance
         balanceDecimal
         balanceUsd
-        withdrawn
-        withdrawnDecimal
-        withdrawnUsd
         modifiedAt
         modifiedAtBlock
         modifiedAtTransaction
+        token {
+          address
+        }
+        withdrawn
+        withdrawnDecimal
+        withdrawnUsd
       }
     }
   }
@@ -27,12 +30,15 @@ type TokenOfPartner = {
   balance: string;
   balanceDecimal: string;
   balanceUsd: string;
-  withdrawn: string;
-  withdrawnDecimal: string;
-  withdrawnUsd: string;
   modifiedAt: string;
   modifiedAtBlock: string;
   modifiedAtTransaction: string;
+  token: {
+    address: string;
+  };
+  withdrawn: string;
+  withdrawnDecimal: string;
+  withdrawnUsd: string;
 };
 
 type PartnerTokensResponse = {

--- a/packages/frontend/src/hooks/usePartnerWithdraw.tsx
+++ b/packages/frontend/src/hooks/usePartnerWithdraw.tsx
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query';
+import { useWalletClient } from 'wagmi';
+import { STAR_VAULT_ABI, SIFI_CONTRACT_ADDRESS } from 'src/constants';
+import { showToast } from '@sifi/shared-ui';
+import { getEvmTxUrl } from 'src/utils';
+import { getChainById } from 'src/utils/chains';
+
+const usePartnerWithdraw = () => {
+  const { data: walletClient } = useWalletClient();
+
+  return useMutation(
+    ['partnerWithdraw'],
+    async ({ tokenAddress, chainId }: { tokenAddress: string; chainId: number }) => {
+      if (!walletClient) throw new Error('WalletClient not initialised, is the user connected?');
+
+      const chain = getChainById(chainId);
+
+      const receipt = await walletClient.writeContract({
+        chain,
+        address: SIFI_CONTRACT_ADDRESS,
+        abi: STAR_VAULT_ABI,
+        functionName: 'partnerWithdraw',
+        args: [tokenAddress],
+      });
+
+      if (receipt) {
+        const explorerLink = getEvmTxUrl(chain, receipt);
+
+        showToast({
+          text: 'Withdrawal successful',
+          type: 'success',
+          ...(explorerLink ? { link: { text: 'View Transaction', href: explorerLink } } : {}),
+        });
+
+        return receipt;
+      }
+    }
+  );
+};
+
+export { usePartnerWithdraw };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -41,7 +41,7 @@ const TokenRow: FC<TokenRowProps> = ({
   const tokenDetails = tokensByChainIdAndAddress[tokenKey];
   const showWithdrawalButton = Number(token.balanceDecimal) > 0 && !withdrawnTokens[tokenAddress];
   const lastWithdrwalHash = withdrawnTokens[token.id] || token.modifiedAtTransaction;
-  const lastWithdrwalUrl = getEvmTxUrl(
+  const lastWithdrawalUrl = getEvmTxUrl(
     getChainById(Number(chainId)),
     withdrawnTokens[token.id] || token.modifiedAtTransaction
   );
@@ -83,7 +83,7 @@ const TokenRow: FC<TokenRowProps> = ({
                 <div>
                   <a
                     className="dark:text-pixel-blue underline"
-                    href={lastWithdrwalUrl}
+                    href={lastWithdrawalUrl}
                     target="_blank"
                     rel="noreferrer"
                     aria-label={`Link to last withdrawal transaction ${firstAndLast(

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { Skeleton, Table, formatTokenAmount } from '@sifi/shared-ui';
 import { FC, useEffect, useState } from 'react';
 import { Button } from 'src/components/Button';
-import { PartnerTokens, usePartnerTokens } from 'src/hooks/usePartnerTokens';
+import { PartnerTokens } from 'src/hooks/usePartnerTokens';
 import { getChainById, getChainIcon } from 'src/utils/chains';
 import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi';
 import { useFetchTokens } from 'src/hooks/useFetchTokens';
@@ -9,41 +9,12 @@ import { usePartnerWithdraw } from 'src/hooks/usePartnerWithdraw';
 import { ConnectWallet } from 'src/components/ConnectWallet/ConnectWallet';
 import { firstAndLast, getEvmTxUrl } from 'src/utils';
 import { ETH_CONTRACT_ADDRESS, ETH_ZERO_ADDRESS } from 'src/constants';
+import { usePartnerData } from 'src/hooks/usePartnerData';
 
 const extractTokenAddress = (id: string): string => {
   // The id is a concatenation of two Ethereum addresses,
   // the token address is last 40 characters of the id.
   return '0x' + id.slice(-40);
-};
-
-const calculateTotalBalanceUsd = (partnerTokens: PartnerTokens) => {
-  return partnerTokens
-    ? Object.values(partnerTokens).reduce((total, data) => {
-        if (data?.partner?.tokens) {
-          const totalForChain = data.partner.tokens.reduce(
-            (total, token) => total + parseFloat(token.balanceUsd),
-            0
-          );
-          return total + totalForChain;
-        }
-        return parseFloat(total.toFixed(2));
-      }, 0)
-    : 0;
-};
-
-const calculateLifetimeEarningsUsd = (partnerTokens: PartnerTokens) => {
-  return partnerTokens
-    ? Object.values(partnerTokens).reduce((total, data) => {
-        if (data?.partner?.tokens) {
-          const totalForChain = data.partner.tokens.reduce(
-            (total, token) => total + parseFloat(token.balanceUsd) + parseFloat(token.withdrawnUsd),
-            0
-          );
-          return total + totalForChain;
-        }
-        return parseFloat(total.toFixed(2));
-      }, 0)
-    : 0;
 };
 
 type PartnerTokensTableProps = {
@@ -184,9 +155,9 @@ const PartnerTokensTable: FC<PartnerTokensTableProps> = ({ partnerTokens }) => {
 
 const Dashboard = () => {
   const { address, isConnected } = useAccount();
-  const { data: partnerTokens, isLoading } = usePartnerTokens(address || '');
-  const totalBalanceUsd = partnerTokens ? calculateTotalBalanceUsd(partnerTokens) : 0;
-  const lifetimeEarningsUsd = partnerTokens ? calculateLifetimeEarningsUsd(partnerTokens) : 0;
+  const { partnerTokens, totalBalanceUsd, lifetimeEarningsUsd, isLoading } = usePartnerData(
+    address || ''
+  );
 
   return (
     <section className="mt-8 min-h-[50rem]">

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -153,6 +153,29 @@ const PartnerTokensTable: FC<PartnerTokensTableProps> = ({ partnerTokens }) => {
   );
 };
 
+const StatsCard = ({
+  title,
+  value,
+  isLoading,
+}: {
+  title: string;
+  value: number;
+  isLoading: boolean;
+}) => (
+  <div className="flex flex-wrap place-items-center text-center gap-x-4 gap-y-2 bg-white px-4 py-5 sm:px-6 xl:px-8">
+    <dt className="text-sm font-medium text-gray-500 text-center w-full">{title}</dt>
+    <dd className="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900 justify-center">
+      {isLoading ? (
+        <div>
+          <Skeleton className="h-10" />
+        </div>
+      ) : (
+        <div>{value} USD</div>
+      )}
+    </dd>
+  </div>
+);
+
 const Dashboard = () => {
   const { address, isConnected } = useAccount();
   const { partnerTokens, totalBalanceUsd, lifetimeEarningsUsd, isLoading } = usePartnerData(
@@ -167,34 +190,12 @@ const Dashboard = () => {
       {isConnected ? (
         <>
           <dl className="mx-auto grid grid-cols-2 gap-px bg-gray-900/5 place-items-center max-w-md">
-            <div className="flex flex-wrap place-items-center text-center gap-x-4 gap-y-2 bg-white px-4 py-5 sm:px-6 xl:px-8">
-              <dt className="text-sm font-medium text-gray-500 text-center w-full">
-                Lifetime Earnings
-              </dt>
-              <dd className="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900 justify-center">
-                {isLoading ? (
-                  <div>
-                    <Skeleton className="h-10" />
-                  </div>
-                ) : (
-                  <div>{lifetimeEarningsUsd} USD</div>
-                )}
-              </dd>
-            </div>
-            <div className="flex flex-wrap place-items-center text-center gap-x-4 gap-y-2 bg-white px-4 py-5 sm:px-6 xl:px-8">
-              <dt className="text-sm font-medium text-gray-500 text-center w-full">
-                Withdrawable Amount
-              </dt>
-              <dd className="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900 justify-center">
-                {isLoading ? (
-                  <div>
-                    <Skeleton className="h-10" />
-                  </div>
-                ) : (
-                  <div>{totalBalanceUsd} USD</div>
-                )}
-              </dd>
-            </div>
+            <StatsCard
+              title="Lifetime Earnings"
+              value={lifetimeEarningsUsd}
+              isLoading={isLoading}
+            />
+            <StatsCard title="Withdrawable Amount" value={totalBalanceUsd} isLoading={isLoading} />
           </dl>
           {partnerTokens && <PartnerTokensTable partnerTokens={partnerTokens} />}
         </>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -136,7 +136,7 @@ const PartnerTokensTable: FC<PartnerTokensTableProps> = ({ partnerTokensByChain 
     <section>
       <div className="mx-auto w-full max-w-xl">
         <div className="flex flex-col items-center justify-between gap-2">
-          <div className="dark:border-darker-gray border-smoke w-full border-t mt-4">
+          <div className=" w-full mt-4">
             <Table>
               <Table.Body>
                 {Object.entries(partnerTokensByChain).map(

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -49,6 +49,7 @@ const TokenRow: FC<TokenRowProps> = ({
     getChainById(Number(chainId)),
     withdrawnTokens[token.id] || token.modifiedAtTransaction
   );
+  const hasBalance = Number(token.balanceDecimal) > 0;
 
   return (
     <Table.Row className="overflow-y-auto max-w-xs m-auto sm:max-w-none my-2" key={token.id}>
@@ -64,10 +65,10 @@ const TokenRow: FC<TokenRowProps> = ({
                 />
               </div>
               <div className="flex flex-col pl-4">
-                <span>
-                  {formatTokenAmount(token.balanceDecimal)} {tokenDetails?.symbol}
+                <span>{`${formatTokenAmount(token.balanceDecimal)} ${tokenDetails?.symbol}`}</span>
+                <span className="text-sm">
+                  {hasBalance && `≈ ${formatTokenAmount(token.balanceUsd)} USD`}
                 </span>
-                <span className="text-sm">≈ {formatTokenAmount(token.balanceUsd)} USD</span>
               </div>
             </div>
           </div>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,234 @@
+import { Skeleton, Table, formatTokenAmount } from '@sifi/shared-ui';
+import { FC, useEffect, useState } from 'react';
+import { Button } from 'src/components/Button';
+import { PartnerTokens, usePartnerTokens } from 'src/hooks/usePartnerTokens';
+import { getChainById, getChainIcon } from 'src/utils/chains';
+import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi';
+import { useFetchTokens } from 'src/hooks/useFetchTokens';
+import { usePartnerWithdraw } from 'src/hooks/usePartnerWithdraw';
+import { ConnectWallet } from 'src/components/ConnectWallet/ConnectWallet';
+import { firstAndLast, getEvmTxUrl } from 'src/utils';
+
+const extractTokenAddress = (id: string): string => {
+  // The id is a concatenation of two Ethereum addresses,
+  // the token address is last 40 characters of the id.
+  return '0x' + id.slice(-40);
+};
+
+const calculateTotalBalanceUsd = (partnerTokens: PartnerTokens) => {
+  return partnerTokens
+    ? Object.values(partnerTokens).reduce((total, data) => {
+        if (data?.partner?.tokens) {
+          const totalForChain = data.partner.tokens.reduce(
+            (total, token) => total + parseFloat(token.balanceUsd),
+            0
+          );
+          return total + totalForChain;
+        }
+        return parseFloat(total.toFixed(2));
+      }, 0)
+    : 0;
+};
+
+const calculateLifetimeEarningsUsd = (partnerTokens: PartnerTokens) => {
+  return partnerTokens
+    ? Object.values(partnerTokens).reduce((total, data) => {
+        if (data?.partner?.tokens) {
+          const totalForChain = data.partner.tokens.reduce(
+            (total, token) => total + parseFloat(token.balanceUsd) + parseFloat(token.withdrawnUsd),
+            0
+          );
+          return total + totalForChain;
+        }
+        return parseFloat(total.toFixed(2));
+      }, 0)
+    : 0;
+};
+
+type PartnerTokensTableProps = {
+  partnerTokens: PartnerTokens;
+};
+
+const PartnerTokensTable: FC<PartnerTokensTableProps> = ({ partnerTokens }) => {
+  const { chain: activeChain } = useNetwork();
+  const { switchNetwork } = useSwitchNetwork();
+  const chainIds = Object.keys(partnerTokens).map(Number);
+  const { fetchTokens, tokensByAddress } = useFetchTokens(chainIds);
+  const [withdrawnTokens, setWithdrawnTokens] = useState<{ [key: string]: string }>({});
+
+  useEffect(() => {
+    fetchTokens();
+  }, []);
+
+  const partnerWithdrawMutation = usePartnerWithdraw();
+
+  const handleWithdraw = async (id: string, chainId: number) => {
+    const tokenAddress = extractTokenAddress(id);
+
+    if (switchNetwork && chainId !== activeChain?.id) {
+      switchNetwork(chainId);
+    }
+
+    partnerWithdrawMutation.mutate(
+      { tokenAddress, chainId },
+      {
+        onSuccess: async receipt => {
+          if (receipt) {
+            // Refetching is not reliable, so we just update the state manually
+            setWithdrawnTokens(prev => ({ ...prev, [id]: receipt }));
+          }
+        },
+      }
+    );
+  };
+
+  return (
+    <section>
+      <div className="mx-auto w-full max-w-xl">
+        <div className="flex flex-col items-center justify-between gap-2">
+          <div className="dark:border-darker-gray border-smoke w-full border-t mt-4">
+            <Table>
+              <Table.Body>
+                {Object.entries(partnerTokens).map(
+                  ([chainId, data]) =>
+                    data?.partner?.tokens?.map(token => {
+                      const tokenAddress = extractTokenAddress(token.id);
+                      const tokenDetails = tokensByAddress[tokenAddress];
+                      const showWithdrawalButton =
+                        Number(token.balanceDecimal) > 0 && !withdrawnTokens[token.id];
+                      const lastWithdrwalHash =
+                        withdrawnTokens[token.id] || token.modifiedAtTransaction;
+                      const lastWithdrwalUrl = getEvmTxUrl(
+                        getChainById(Number(chainId)),
+                        withdrawnTokens[token.id] || token.modifiedAtTransaction
+                      );
+
+                      return (
+                        <Table.Row
+                          className="overflow-y-auto max-w-xs m-auto sm:max-w-none my-2"
+                          key={token.id}
+                        >
+                          <Table.Cell className="mb-2 w-full sm:mb-0">
+                            <div className="mx-auto grid items-center sm:grid-cols-2">
+                              <div className="mb-4 sm:mb-0 sm:inline-block sm:pl-8">
+                                <div className="flex items-center justify-center sm:justify-start">
+                                  <div className="relative mr-3 ">
+                                    <img
+                                      className="h-12 w-12 rounded-full"
+                                      src={tokenDetails?.logoURI}
+                                      alt="Logo"
+                                    />
+                                    <img
+                                      src={getChainIcon(tokenDetails?.chainId)}
+                                      className="w-6 h-6 -right-1 -bottom-1 absolute"
+                                    />
+                                  </div>
+                                  <div className="flex flex-col pl-4">
+                                    <span>
+                                      {formatTokenAmount(token.balanceDecimal)}{' '}
+                                      {tokensByAddress[tokenAddress]?.symbol}
+                                    </span>
+                                    <span className="text-sm">
+                                      ≈ {formatTokenAmount(token.balanceUsd)} USD
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                              <div className="flex place-items-center align-middle justify-center my-2 sm:m-auto">
+                                {showWithdrawalButton ? (
+                                  <Button
+                                    role="button"
+                                    size="small"
+                                    onClick={() => handleWithdraw(token.id, Number(chainId))}
+                                  >
+                                    Withdraw
+                                  </Button>
+                                ) : (
+                                  <div className="text-center">
+                                    Last withdrawal:
+                                    <div>
+                                      <a
+                                        className="dark:text-pixel-blue underline"
+                                        href={lastWithdrwalUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        aria-label={`Link to last withdrawal transaction ${firstAndLast(
+                                          lastWithdrwalHash
+                                        )} on the block explorer`}
+                                      >
+                                        {firstAndLast(lastWithdrwalHash)}
+                                      </a>
+                                    </div>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </Table.Cell>
+                        </Table.Row>
+                      );
+                    })
+                )}
+              </Table.Body>
+            </Table>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const Dashboard = () => {
+  const { address, isConnected } = useAccount();
+  const { data: partnerTokens, isLoading } = usePartnerTokens(address || '');
+  const totalBalanceUsd = partnerTokens ? calculateTotalBalanceUsd(partnerTokens) : 0;
+  const lifetimeEarningsUsd = partnerTokens ? calculateLifetimeEarningsUsd(partnerTokens) : 0;
+
+  return (
+    <section className="mt-8 min-h-[50rem]">
+      <h1 className="text-flashbang-white font-display mb-2 pb-0 text-center text-2xl sm:text-3xl">
+        Dashboard
+      </h1>
+      {isConnected ? (
+        <>
+          <dl className="mx-auto grid grid-cols-2 gap-px bg-gray-900/5 place-items-center max-w-md">
+            <div className="flex flex-wrap place-items-center text-center gap-x-4 gap-y-2 bg-white px-4 py-5 sm:px-6 xl:px-8">
+              <dt className="text-sm font-medium text-gray-500 text-center w-full">
+                Lifetime Earnings
+              </dt>
+              <dd className="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900 justify-center">
+                {isLoading ? (
+                  <div>
+                    <Skeleton className="h-10" />
+                  </div>
+                ) : (
+                  <div>{lifetimeEarningsUsd} USD</div>
+                )}
+              </dd>
+            </div>
+            <div className="flex flex-wrap place-items-center text-center gap-x-4 gap-y-2 bg-white px-4 py-5 sm:px-6 xl:px-8">
+              <dt className="text-sm font-medium text-gray-500 text-center w-full">
+                Withdrawable Amount
+              </dt>
+              <dd className="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900 justify-center">
+                {isLoading ? (
+                  <div>
+                    <Skeleton className="h-10" />
+                  </div>
+                ) : (
+                  <div>{totalBalanceUsd} USD</div>
+                )}
+              </dd>
+            </div>
+          </dl>
+          {partnerTokens && <PartnerTokensTable partnerTokens={partnerTokens} />}
+        </>
+      ) : (
+        <div className="mt-12 flex justify-center">
+          <ConnectWallet />
+        </div>
+      )}
+    </section>
+  );
+};
+
+export { Dashboard };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -68,7 +68,7 @@ const TokenRow: FC<TokenRowProps> = ({
               </div>
             </div>
           </div>
-          <div className="flex place-items-center align-middle justify-center my-2 sm:m-auto">
+          <Table.Cell className="flex place-items-center align-middle justify-center my-2 sm:m-auto">
             {showWithdrawalButton ? (
               <Button
                 role="button"
@@ -95,7 +95,7 @@ const TokenRow: FC<TokenRowProps> = ({
                 </div>
               </div>
             )}
-          </div>
+          </Table.Cell>
         </div>
       </Table.Cell>
     </Table.Row>


### PR DESCRIPTION
Users can collect referral rewards by referring other users. The Dashboard is where they can see related stats and withdraw rewards.

### Changes Made
- Adds the new Dashboard page, and links in the header and footer for navigation.
- Adds two new hooks. `usePartnerToken` retrieves the partner token data from all the supported chains via subgraphs. `usePartnerWithdraw` handles withdrawing tokens via interacting with the `StarVault` smart contract.
- Adds `tokensByAddress` token dictionary to `useFetchTokens` so tokens can easily found by their address

### Notes
- If the user is not connected to the correct network, the Withdraw button triggers a network switch first. We should probably display a network selector akin to the one reverted in #414, but it should show the currently active chain, not the one selected in `fromChain`.
- Could not find a way to reliable refetch after withdraw to update the UI, therefore we're updating the state manually right after the withdraw has happened. I've also set refetch on `usePartnerTokens to 15 seconds to get a frequent updates without hammering the API. 

### Screenshots

![image](https://github.com/sifiorg/sifi/assets/128667801/56300675-ddf9-4eb4-9a1c-5ebb6037947c)
![image](https://github.com/sifiorg/sifi/assets/128667801/449b4de9-f26a-4a59-bd21-468f56d61dce)

### Video

https://github.com/sifiorg/sifi/assets/128667801/343bb4c1-4b14-47b9-a5f5-07bf03f9193c

### Testing
- [x] Partner token list shows up on the UI with the correct data
- [x] Withdrawal works - _Can be tested with the Sifi testing wallet. You can generate balances by setting wallet address as the referral in the code 
- [x] UI updates withdrawal
- [x] Block explorers work 
- [x] Tokens list still fetches in CreateSwap
- [x] Token swaps still work
- [ ] Add stories
- [ ] Add e2e testing?

