### PR TITLE
feat(sdk): pass entire quote to getSwap

### DIFF
--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -1,0 +1,6 @@
+/**
+ * Serializes a value to JSON, converting any BigInts to strings.
+ */
+export function serializeJson(value: any) {
+  return JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
+}


### PR DESCRIPTION
Passing the entire quote instead of relying on a backend to store the quote and retrieve it by ID enables a few different features later:

- The SDK can call a different path finder instance/type to build the tx from the quote
- The SDK could contain the code the builds the tx from the quote, removing the need for the getSwap call

The code quality of the SDK is still pretty low, but it's small enough for now to live with.

## Testing

- [x] Swap from ETH
- [x] Swap from token

The types of `quote.source.data` are not included in this PR. Once we add them, the frontend can render a "swap diagram" that shows how the swap will route through various tokens, splits, etc.
