### PR TITLE
feat(frontend): allow fetching tokens from multiple networks

### DIFF
--- a/packages/frontend/src/providers/TokensProvider.tsx
+++ b/packages/frontend/src/providers/TokensProvider.tsx
@@ -32,8 +32,8 @@ const TokensProvider: FunctionComponent<{ children: ReactNode }> = ({ children }
   const { fromChain, toChain } = useSwapFormValues();
   const [fromTokens, setFromTokens] = useState<Token[]>([]);
   const [toTokens, setToTokens] = useState<Token[]>([]);
-  const { fetchTokens: fetchFromTokens } = useFetchTokens(fromChain.id);
-  const { fetchTokens: fetchToTokens } = useFetchTokens(toChain.id);
+  const { fetchTokens: fetchFromTokens } = useFetchTokens([fromChain.id]);
+  const { fetchTokens: fetchToTokens } = useFetchTokens([toChain.id]);
 
   useEffect(() => {
     const shouldRefetchFromTokens = fromChain.id !== fromTokens?.[0]?.chainId;


### PR DESCRIPTION
Allows fetching chains from multiple networks. This is required for the Dashboard, as we have to work with tokens on different networks there. #401 

![image](https://github.com/sifiorg/sifi/assets/128667801/ea563a5a-92f7-4285-b4a3-4828071e9ddb)


