### PR TITLE
chore(frontend): upgrade shared-ui to 1.8.11

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.0.12",
     "@sifi/sdk": "~1.11.0",
-    "@sifi/shared-ui": "^1.8.5",
+    "@sifi/shared-ui": "^1.8.11",
     "@tanstack/react-query": "^4.13.0",
     "@types/three": "^0.127.1",
     "@uniswap/permit2-sdk": "^1.2.0",

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import HeaderMenu from '../HeaderMenu/HeaderMenu';
 const Header: FunctionComponent = () => {
   return (
     <>
-      <Navbar logo={logo}>
+      <Navbar Logo={<img src="logo" alt="Sifi logo" />}>
         <HeaderMenu />
       </Navbar>
     </>

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -1,14 +1,12 @@
 import { FunctionComponent } from 'react';
 import { Navbar } from '@sifi/shared-ui';
-import logo from 'src/assets/logoWhite.svg';
+import { ReactComponent as Logo } from 'src/assets/logoWhite.svg';
 import HeaderMenu from '../HeaderMenu/HeaderMenu';
-
-const Logo = () => <img src={logo} alt="Sifi logo" className="max-h-[2rem]" />;
 
 const Header: FunctionComponent = () => {
   return (
     <>
-      <Navbar Logo={Logo}>
+      <Navbar Logo={<Logo alt="Sifi logo" className="max-h-[2rem]" />}>
         <HeaderMenu />
       </Navbar>
     </>

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -3,10 +3,12 @@ import { Navbar } from '@sifi/shared-ui';
 import logo from 'src/assets/logoWhite.svg';
 import HeaderMenu from '../HeaderMenu/HeaderMenu';
 
+const Logo = () => <img src={logo} alt="Sifi logo" className="max-h-[2rem]" />;
+
 const Header: FunctionComponent = () => {
   return (
     <>
-      <Navbar Logo={<img src="logo" alt="Sifi logo" />}>
+      <Navbar Logo={Logo}>
         <HeaderMenu />
       </Navbar>
     </>

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -1,12 +1,14 @@
 import { FunctionComponent } from 'react';
 import { Navbar } from '@sifi/shared-ui';
-import { ReactComponent as Logo } from 'src/assets/logoWhite.svg';
+import { ReactComponent as LogoWhite } from 'src/assets/logoWhite.svg';
 import HeaderMenu from '../HeaderMenu/HeaderMenu';
+
+const Logo = () => <LogoWhite alt="Sifi logo" className="max-h-[2rem]" />;
 
 const Header: FunctionComponent = () => {
   return (
     <>
-      <Navbar Logo={<Logo alt="Sifi logo" className="max-h-[2rem]" />}>
+      <Navbar Logo={Logo}>
         <HeaderMenu />
       </Navbar>
     </>

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -12,7 +12,7 @@ const RecentWarpsTableData: FunctionComponent = () => {
 
   if (error) {
     return (
-      <Table.Row width="100%">
+      <Table.Row className="w-100">
         <Table.Cell className="text-center">
           <span className="dark:text-punk-red">Something went wrong loading the recent warps</span>
         </Table.Cell>

--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -4,7 +4,6 @@ import { useRecentWarps } from 'src/hooks/useRecentWarps';
 import { useTokens } from 'src/hooks/useTokens';
 import { getChainById, getChainIcon } from 'src/utils/chains';
 import { firstAndLast, getEvmTxUrl, getIconFromSymbol } from 'src/utils';
-import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
 const RecentWarpsTableData: FunctionComponent = () => {
   const { data: warps, error, isLoading } = useRecentWarps();
@@ -12,7 +11,7 @@ const RecentWarpsTableData: FunctionComponent = () => {
 
   if (error) {
     return (
-      <Table.Row className="w-100">
+      <Table.Row className="w-full">
         <Table.Cell className="text-center">
           <span className="dark:text-punk-red">Something went wrong loading the recent warps</span>
         </Table.Cell>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ~1.11.0
         version: link:../sdk
       '@sifi/shared-ui':
-        specifier: ^1.8.5
-        version: 1.8.5(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10)
+        specifier: ^1.8.11
+        version: 1.8.11(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10)
       '@tanstack/react-query':
         specifier: ^4.13.0
         version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
@@ -6529,8 +6529,8 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
-  /@sifi/shared-ui@1.8.5(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10):
-    resolution: {integrity: sha512-SJ9GKsv8lpGZbozJhFB0MwGpcBUtwAToaMsS8qqvOGMFimSl7x3r81wdNAGXEQfobVKfekVtXvPtw2kHqlaUvA==}
+  /@sifi/shared-ui@1.8.11(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10):
+    resolution: {integrity: sha512-+PM2jyf3wyMWQ3/P6dOtQ5mrdYYbDiQ1vwrz2k3qwCZ51AVLjRIXLGIqAgEOXl6NkB9d7izm63FJtDcM8aPrsg==}
     peerDependencies:
       '@headlessui/react': ^1.7.3
       date-fns: 2.29.3
@@ -13537,6 +13537,7 @@ packages:
 
   /eip1193-provider@1.0.1:
     resolution: {integrity: sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@json-rpc-tools/provider': 1.7.6
     transitivePeerDependencies:


### PR DESCRIPTION
Upgrades shared-ui to the latest version, which contains several fixes, including one for #442.

Closes #422.