### PR TITLE
fix(frontend): to amount gets cleared when approval is needed

### DIFF
--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -55,6 +55,7 @@ const useQuote = () => {
         toastId: `quote-error-${fromToken?.symbol}-${fromChain.id}-${toToken?.symbol}-${toChain.id}`,
       });
     }
+    setValue(SwapFormKey.ToAmount, '');
   };
 
   const enabled =
@@ -78,10 +79,11 @@ const useQuote = () => {
     retry: failureCount => failureCount < 1, // Retry once on failure
   });
 
-  // To avoid showing the last quote
   useEffect(() => {
-    setValue(SwapFormKey.ToAmount, '');
-  }, [fromAmount, fromToken, toToken]);
+    if (!enabled) {
+      setValue(SwapFormKey.ToAmount, '');
+    }
+  }, [enabled]);
 
   return {
     quote,

--- a/packages/frontend/src/utils/queries.tsx
+++ b/packages/frontend/src/utils/queries.tsx
@@ -1,16 +1,13 @@
-import { type Token } from "@sifi/sdk";
+import { type Token } from '@sifi/sdk';
 
 export const getQueryKey = (
   primaryKey: string,
   fromAmount?: string,
   fromToken?: Token | null,
-  toToken?: Token | null,
+  toToken?: Token | null
 ) => [
-  primaryKey, {
-    fromAmount,
-    toTokenAddress: toToken?.address,
-    fromTokenAddress: fromToken?.address,
-    toChainId: toToken?.chainId,
-    fromChainId: fromToken?.chainId,
-  }
+  primaryKey,
+  fromAmount,
+  `${toToken?.address}${toToken?.chainId}`,
+  `${fromToken?.address}${fromToken?.chainId}`,
 ];


### PR DESCRIPTION
### Changes Made

- Refactor `useQuote` to handle refetching, and when to clear the inputs by removing the original `useEffect` that caused this issue
- Restructure the query keys. React Query knows when to re-run the query based on when the query key changes, however it can't properly do that, because inside of the query key is an object with all the properties, instead of just strings which is more failproof

### Screenshots/videos

https://github.com/sifiorg/sifi/assets/128688932/7207adbc-7ef5-4fa0-93cb-3325eb038020

### Testing

- [x] Input is not cleared when approval is needed
- [x] No invalid quote amounts are shown

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #415 
