### PR TITLE
fix(frontend): handle null token symbols

### DIFF
--- a/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
+++ b/packages/frontend/src/components/RecentWarps/RecentWarps.tsx
@@ -59,7 +59,7 @@ const RecentWarpsTableData: FunctionComponent = () => {
                       />
                     </div>
                     <span>{`${formatTokenAmount(warp.amountInDecimal)} ${
-                      warp.tokenIn.symbol
+                      warp.tokenIn.symbol || '?'
                     }`}</span>
                   </div>
                 </div>

--- a/packages/frontend/src/utils/getIconFromSymbol.tsx
+++ b/packages/frontend/src/utils/getIconFromSymbol.tsx
@@ -3,6 +3,8 @@ import { getTokenBySymbol } from './tokens';
 import MissingTokenIcon from 'src/assets/icons/missing-token-icon.svg';
 
 const getIconFromSymbol = (symbol: string, tokens: Token[]) => {
+  if (!symbol) return MissingTokenIcon;
+
   let logoURI = getTokenBySymbol(symbol, tokens)?.logoURI;
 
   // Symbol from the SDK is sometimes inconsistent


### PR DESCRIPTION
Quick fix - this is causing the site to crash so we should merge this asap.

Below token was causing a crash in recent deposits when trying to fetch a null token symbol.

![image](https://github.com/sifiorg/sifi/assets/112887817/ccc0abc1-15c1-4f2d-b0e1-8a77bc247e98)
