### PR TITLE
refactor(frontend): CreateSwap

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -1,13 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useForm, useFormContext } from 'react-hook-form';
-import { useAccount, useNetwork } from 'wagmi';
 import { ShiftInput } from '@sifi/shared-ui';
 import { useTokens } from 'src/hooks/useTokens';
 import { useTokenBalance } from 'src/hooks/useTokenBalance';
 import { getTokenBySymbol } from 'src/utils';
 import { SwapFormKey, SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
 import { useCullQueries } from 'src/hooks/useCullQueries';
-import { useSpendableBalance } from 'src/hooks/useSpendableBalance';
 import { useQuote } from 'src/hooks/useQuote';
 import { useReferrer } from 'src/hooks/useReferrer';
 import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
@@ -27,7 +25,7 @@ import { useExecuteSwap } from 'src/hooks/useExecuteSwap';
 const CreateSwap = () => {
   useCullQueries('quote');
   useSyncTokenUrlParams();
-  const { isConnected } = useAccount();
+  useReferrer();
   const {
     fromToken: fromTokenSymbol,
     toToken: toTokenSymbol,
@@ -72,11 +70,9 @@ const CreateSwap = () => {
   const selectedToToken = getTokenBySymbol(toTokenSymbol, toTokens) || undefined;
   const fromId = SwapFormKeyHelper.getAmountKey('from');
   const toId = SwapFormKeyHelper.getAmountKey('to');
-  const spendableBalance = useSpendableBalance({ token: fromToken });
-  const depositMax = isConnected ? spendableBalance : undefined;
   const selectedFromTokenWithNetwork = getTokenWithNetwork(selectedFromToken, fromChain);
   const selectedToTokenWithNetwork = getTokenWithNetwork(selectedToToken, toChain);
-  const { chain } = useNetwork();
+
   const fromUsdValue = useUsdValue({
     address: fromToken?.address,
     chainId: fromChain.id,
@@ -87,9 +83,6 @@ const CreateSwap = () => {
     chainId: toChain?.id,
     amount: toAmount,
   });
-  const userIsConnectedToWrongNetwork = Boolean(
-    chain?.id && fromToken?.chainId && chain.id !== fromToken.chainId
-  );
 
   const resetTokenAmounts = () => {
     setValue(SwapFormKey.FromAmount, '');
@@ -127,7 +120,7 @@ const CreateSwap = () => {
                   openSelector={() => openTokenSelector('from')}
                   formMethods={methods}
                   disabled={Boolean(isSameTokenPair)}
-                  max={userIsConnectedToWrongNetwork ? undefined : depositMax}
+                  max={depositMax}
                   usdValue={fromUsdValue}
                   hideLabel
                 />

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -21,11 +21,14 @@ import { useSyncTokenUrlParams } from 'src/hooks/useSyncTokenUrlParams';
 import { enableSwapInformation } from 'src/utils/featureFlags';
 import { useUsdValue } from 'src/hooks/useUsdValue';
 import { useExecuteSwap } from 'src/hooks/useExecuteSwap';
+import { useDepositMax } from 'src/hooks/useDepositMax';
 
 const CreateSwap = () => {
   useCullQueries('quote');
   useSyncTokenUrlParams();
   useReferrer();
+  useDefaultTokens();
+  const { handleSubmit } = useForm();
   const {
     fromToken: fromTokenSymbol,
     toToken: toTokenSymbol,
@@ -34,36 +37,28 @@ const CreateSwap = () => {
     fromChain,
     toChain,
   } = useSwapFormValues();
-  const { handleSubmit } = useForm();
   const { fromTokens, toTokens } = useTokens();
   const { balanceMap: fromBalanceMap } = useMultiCallTokenBalance(
     fromTokens as MulticallToken[],
     fromChain.id
   );
-
   const { balanceMap: toTokenBalanceMap } = useMultiCallTokenBalance(
     toTokens as MulticallToken[],
     toChain.id
   );
+  const { executeSwap } = useExecuteSwap();
+  const { depositMax } = useDepositMax();
+  const { isFetching: isFetchingQuote } = useQuote();
   const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
   const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
-  const { isFetching: isFetchingQuote } = useQuote();
   const ShiftInputLabel = { from: 'From', to: 'To' } as const;
   const { data: fromBalance } = useTokenBalance(fromToken, fromChain.id);
   const { data: toBalance } = useTokenBalance(toToken, toChain.id);
   const isSameTokenPair =
     fromToken && toToken && fromToken.address === toToken.address && fromChain === toChain;
-
   const isToSwapInputLoading = isFetchingQuote;
-
-  useReferrer();
-  useDefaultTokens();
-
-  const { executeSwap } = useExecuteSwap();
-
   const { closeTokenSelector, openTokenSelector, tokenSelectorType, isTokenSelectorOpen } =
     useTokenSelector();
-
   const { setValue } = useFormContext();
   const methods = useFormContext();
   const selectedFromToken = getTokenBySymbol(fromTokenSymbol, fromTokens) || undefined;
@@ -72,7 +67,6 @@ const CreateSwap = () => {
   const toId = SwapFormKeyHelper.getAmountKey('to');
   const selectedFromTokenWithNetwork = getTokenWithNetwork(selectedFromToken, fromChain);
   const selectedToTokenWithNetwork = getTokenWithNetwork(selectedToToken, toChain);
-
   const fromUsdValue = useUsdValue({
     address: fromToken?.address,
     chainId: fromChain.id,

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -1,25 +1,20 @@
 import { useEffect, useState } from 'react';
 import { useForm, useFormContext } from 'react-hook-form';
-import { useAccount, useWalletClient, usePublicClient, useNetwork } from 'wagmi';
-import { parseUnits } from 'viem';
-import { showToast, ShiftInput } from '@sifi/shared-ui';
+import { useAccount, useNetwork } from 'wagmi';
+import { ShiftInput } from '@sifi/shared-ui';
 import { useTokens } from 'src/hooks/useTokens';
 import { useTokenBalance } from 'src/hooks/useTokenBalance';
-import { useMutation } from '@tanstack/react-query';
-import { useSifi } from 'src/providers/SDKProvider';
-import { getEvmTxUrl, getTokenBySymbol, getViemErrorMessage } from 'src/utils';
+import { getTokenBySymbol } from 'src/utils';
 import { SwapFormKey, SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
 import { useCullQueries } from 'src/hooks/useCullQueries';
 import { useSpendableBalance } from 'src/hooks/useSpendableBalance';
 import { useQuote } from 'src/hooks/useQuote';
 import { useReferrer } from 'src/hooks/useReferrer';
-import { localStorageKeys } from 'src/utils/localStorageKeys';
 import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
 import { TokenSelector, useTokenSelector } from '../TokenSelector';
 import { SwapInformation } from '../SwapInformation';
 import { MulticallToken } from 'src/types';
 import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
-import { usePermit2 } from 'src/hooks/usePermit2';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
@@ -27,14 +22,12 @@ import { useDefaultTokens } from 'src/hooks/useDefaultTokens';
 import { useSyncTokenUrlParams } from 'src/hooks/useSyncTokenUrlParams';
 import { enableSwapInformation } from 'src/utils/featureFlags';
 import { useUsdValue } from 'src/hooks/useUsdValue';
-import { useSpaceTravel } from 'src/providers/SpaceTravelProvider';
-import { defaultFeeBps } from 'src/config';
+import { useExecuteSwap } from 'src/hooks/useExecuteSwap';
 
 const CreateSwap = () => {
   useCullQueries('quote');
   useSyncTokenUrlParams();
-  const { address, isConnected } = useAccount();
-  const sifi = useSifi();
+  const { isConnected } = useAccount();
   const {
     fromToken: fromTokenSymbol,
     toToken: toTokenSymbol,
@@ -43,131 +36,34 @@ const CreateSwap = () => {
     fromChain,
     toChain,
   } = useSwapFormValues();
-  const publicClient = usePublicClient({ chainId: fromChain.id });
-  const { data: walletClient } = useWalletClient();
   const { handleSubmit } = useForm();
   const { fromTokens, toTokens } = useTokens();
-  const { balanceMap: fromBalanceMap, refetch: refetchFromTokenBalances } =
-    useMultiCallTokenBalance(fromTokens as MulticallToken[], fromChain.id);
-
-  const { balanceMap: toTokenBalanceMap, refetch: refetchToTokenBalances } =
-    useMultiCallTokenBalance(toTokens as MulticallToken[], toChain.id);
-  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
-  const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
-  const [isLoading, setIsLoading] = useState(false);
-  const { quote, isFetching: isFetchingQuote } = useQuote();
-  const ShiftInputLabel = { from: 'From', to: 'To' } as const;
-  const { data: fromBalance, refetch: refetchFromBalance } = useTokenBalance(
-    fromToken,
+  const { balanceMap: fromBalanceMap } = useMultiCallTokenBalance(
+    fromTokens as MulticallToken[],
     fromChain.id
   );
-  const { data: toBalance, refetch: refetchToBalance } = useTokenBalance(toToken, toChain.id);
-  const { getPermit2Params } = usePermit2();
+
+  const { balanceMap: toTokenBalanceMap } = useMultiCallTokenBalance(
+    toTokens as MulticallToken[],
+    toChain.id
+  );
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+  const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
+  const [isLoading] = useState(false);
+  const { isFetching: isFetchingQuote } = useQuote();
+  const ShiftInputLabel = { from: 'From', to: 'To' } as const;
+  const { data: fromBalance } = useTokenBalance(fromToken, fromChain.id);
+  const { data: toBalance } = useTokenBalance(toToken, toChain.id);
   const isSameTokenPair =
     fromToken && toToken && fromToken.address === toToken.address && fromChain === toChain;
 
   const isToSwapInputLoading = isFetchingQuote;
 
-  const { setThrottle } = useSpaceTravel();
-
   useReferrer();
   useDefaultTokens();
 
-  const mutation = useMutation(
-    async () => {
-      if (!quote) {
-        throw new Error('Quote is missing');
-      }
-      if (!walletClient) throw new Error('WalletClient not initialised');
-      if (!address) throw new Error('fromAddress is missing');
-      if (!fromToken) throw new Error('fromToken is missing');
+  const { executeSwap } = useExecuteSwap();
 
-      const partnerAddress = localStorage.getItem(localStorageKeys.REFFERRER_ADDRESS);
-      const partnerFeeBps = localStorage.getItem(localStorageKeys.REFERRER_FEE_BPS);
-
-      const permit =
-        quote.approveAddress && quote.permit2Address
-          ? await getPermit2Params({
-              tokenAddress: fromToken.address,
-              userAddress: address,
-              spenderAddress: quote.approveAddress,
-              permit2Address: quote.permit2Address,
-              amount: parseUnits(fromAmount, fromToken.decimals),
-            })
-          : undefined;
-
-      const { tx } = await sifi.getSwap({
-        fromAddress: address,
-        quote,
-        permit,
-        partner: partnerAddress || undefined,
-        feeBps: partnerFeeBps && partnerAddress ? Number(partnerFeeBps) : defaultFeeBps,
-      });
-
-      const res = await walletClient.sendTransaction({
-        chain: fromChain,
-        data: tx.data as `0x${string}`,
-        account: tx.from as `0x${string}`,
-        to: tx.to as `0x${string}`,
-        gas: BigInt(tx.gasLimit),
-        value: tx.value !== undefined ? BigInt(tx.value) : undefined,
-      });
-      setThrottle(1);
-
-      return res;
-    },
-    {
-      onError: error => {
-        if (error instanceof Error) {
-          showToast({ text: getViemErrorMessage(error), type: 'error' });
-        } else {
-          console.error(error);
-        }
-      },
-      onSettled: () => {
-        setIsLoading(false);
-        setThrottle(0.01);
-      },
-      onSuccess: async hash => {
-        const isJump = fromChain.id !== toChain.id;
-        let explorerLink: string | undefined;
-        if (isJump) {
-          explorerLink = `https://layerzeroscan.com/tx/${hash}`;
-        } else {
-          explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
-        }
-
-        showToast({
-          text: 'Your swap has been confirmed. Please stand by.',
-          type: 'info',
-        });
-
-        await publicClient.waitForTransactionReceipt({ hash });
-
-        showToast({
-          type: 'success',
-          text: 'Your swap has confirmed. It may take a while until it confirms on the blockchain.',
-          ...(explorerLink ? { link: { text: 'View Transaction', href: explorerLink } } : {}),
-          autoClose: false,
-        });
-
-        refetchFromBalance();
-        refetchToBalance();
-        refetchFromTokenBalances();
-        refetchToTokenBalances();
-        setValue(SwapFormKey.FromAmount, '');
-      },
-    }
-  );
-
-  const executeSwap = async () => {
-    if (!fromToken || !toToken) throw new Error('Tokens are missing');
-    if (!address) throw new Error('fromAddress is missing');
-
-    setThrottle(0.25);
-    setIsLoading(true);
-    mutation.mutate();
-  };
   const { closeTokenSelector, openTokenSelector, tokenSelectorType, isTokenSelectorOpen } =
     useTokenSelector();
 

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -46,7 +46,7 @@ const CreateSwap = () => {
     toTokens as MulticallToken[],
     toChain.id
   );
-  const { executeSwap } = useExecuteSwap();
+  const { executeSwap, isLoading } = useExecuteSwap();
   const { depositMax } = useDepositMax();
   const { isFetching: isFetchingQuote } = useQuote();
   const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
@@ -142,7 +142,7 @@ const CreateSwap = () => {
                 type={tokenSelectorType}
               />
               <div className="pt-4">
-                <CreateSwapButtons />
+                <CreateSwapButtons isLoading={isLoading} />
               </div>
             </div>
           </div>

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -49,7 +49,6 @@ const CreateSwap = () => {
   );
   const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
   const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
-  const [isLoading] = useState(false);
   const { isFetching: isFetchingQuote } = useQuote();
   const ShiftInputLabel = { from: 'From', to: 'To' } as const;
   const { data: fromBalance } = useTokenBalance(fromToken, fromChain.id);
@@ -156,7 +155,7 @@ const CreateSwap = () => {
                 type={tokenSelectorType}
               />
               <div className="pt-4">
-                <CreateSwapButtons isLoading={isLoading} />
+                <CreateSwapButtons />
               </div>
             </div>
           </div>

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -14,7 +14,7 @@ import { Button } from '../Button';
 import { ConnectWallet } from '../ConnectWallet/ConnectWallet';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
-const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
+const CreateSwapButtons = () => {
   useCullQueries('routes');
   useCullQueries('quote');
   const { isConnected } = useAccount();
@@ -40,7 +40,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const fromAmountInWei = fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
   const hasSufficientBalance = fromBalance && fromBalance.value >= fromAmountInWei;
 
-  const isSwapButtonLoading = isLoading || isFetchingAllowance || isFetchingQuote;
+  const isSwapButtonLoading = isFetchingAllowance || isFetchingQuote;
 
   const showApproveButton =
     Boolean(

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -14,7 +14,7 @@ import { Button } from '../Button';
 import { ConnectWallet } from '../ConnectWallet/ConnectWallet';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
-const CreateSwapButtons = () => {
+const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   useCullQueries('routes');
   useCullQueries('quote');
   const { isConnected } = useAccount();
@@ -40,7 +40,7 @@ const CreateSwapButtons = () => {
   const fromAmountInWei = fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
   const hasSufficientBalance = fromBalance && fromBalance.value >= fromAmountInWei;
 
-  const isSwapButtonLoading = isFetchingAllowance || isFetchingQuote;
+  const isSwapButtonLoading = isLoading || isFetchingAllowance || isFetchingQuote;
 
   const showApproveButton =
     Boolean(

--- a/packages/frontend/src/hooks/useDepositMax.tsx
+++ b/packages/frontend/src/hooks/useDepositMax.tsx
@@ -1,0 +1,22 @@
+import { useAccount, useNetwork } from 'wagmi';
+import { useSwapFormValues } from './useSwapFormValues';
+import { useTokens } from './useTokens';
+import { getTokenBySymbol } from 'src/utils';
+import { useSpendableBalance } from './useSpendableBalance';
+
+const useDepositMax = () => {
+  const { chain } = useNetwork();
+  const { fromToken: fromTokenSymbol } = useSwapFormValues();
+  const { fromTokens } = useTokens();
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+  const { isConnected } = useAccount();
+  const spendableBalance = useSpendableBalance({ token: fromToken });
+  const depositMax = isConnected ? spendableBalance : undefined;
+  const userIsConnectedToWrongNetwork = Boolean(
+    chain?.id && fromToken?.chainId && chain.id !== fromToken.chainId
+  );
+
+  return { depositMax: userIsConnectedToWrongNetwork ? undefined : depositMax };
+};
+
+export { useDepositMax };

--- a/packages/frontend/src/hooks/useExecuteSwap.tsx
+++ b/packages/frontend/src/hooks/useExecuteSwap.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useAccount, useWalletClient, usePublicClient } from 'wagmi';
+import { parseUnits } from 'viem';
+import { showToast } from '@sifi/shared-ui';
+import { useTokens } from 'src/hooks/useTokens';
+import { useTokenBalance } from 'src/hooks/useTokenBalance';
+import { useMutation } from '@tanstack/react-query';
+import { useSifi } from 'src/providers/SDKProvider';
+import { getEvmTxUrl, getTokenBySymbol, getViemErrorMessage } from 'src/utils';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { useQuote } from 'src/hooks/useQuote';
+import { localStorageKeys } from 'src/utils/localStorageKeys';
+import { MulticallToken } from 'src/types';
+import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
+import { usePermit2 } from 'src/hooks/usePermit2';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
+import { useSpaceTravel } from 'src/providers/SpaceTravelProvider';
+import { defaultFeeBps } from 'src/config';
+
+const useExecuteSwap = () => {
+  const { address } = useAccount();
+  const sifi = useSifi();
+  const {
+    fromToken: fromTokenSymbol,
+    toToken: toTokenSymbol,
+    fromAmount,
+    fromChain,
+    toChain,
+  } = useSwapFormValues();
+  const publicClient = usePublicClient({ chainId: fromChain.id });
+  const { data: walletClient } = useWalletClient();
+  const { fromTokens, toTokens } = useTokens();
+  const { refetch: refetchFromTokenBalances } = useMultiCallTokenBalance(
+    fromTokens as MulticallToken[],
+    fromChain.id
+  );
+  const { refetch: refetchToTokenBalances } = useMultiCallTokenBalance(
+    toTokens as MulticallToken[],
+    toChain.id
+  );
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+  const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
+  const [isLoading, setIsLoading] = useState(false);
+  const { quote } = useQuote();
+  const { refetch: refetchFromBalance } = useTokenBalance(fromToken, fromChain.id);
+  const { refetch: refetchToBalance } = useTokenBalance(toToken, toChain.id);
+  const { getPermit2Params } = usePermit2();
+  const { setThrottle } = useSpaceTravel();
+  const { setValue } = useFormContext();
+
+  const mutation = useMutation(
+    async () => {
+      if (!quote) {
+        throw new Error('Quote is missing');
+      }
+      if (!walletClient) throw new Error('WalletClient not initialised');
+      if (!address) throw new Error('fromAddress is missing');
+      if (!fromToken) throw new Error('fromToken is missing');
+
+      const partnerAddress = localStorage.getItem(localStorageKeys.REFFERRER_ADDRESS);
+      const partnerFeeBps = localStorage.getItem(localStorageKeys.REFERRER_FEE_BPS);
+
+      const permit =
+        quote.approveAddress && quote.permit2Address
+          ? await getPermit2Params({
+              tokenAddress: fromToken.address,
+              userAddress: address,
+              spenderAddress: quote.approveAddress,
+              permit2Address: quote.permit2Address,
+              amount: parseUnits(fromAmount, fromToken.decimals),
+            })
+          : undefined;
+
+      const { tx } = await sifi.getSwap({
+        fromAddress: address,
+        quote,
+        permit,
+        partner: partnerAddress || undefined,
+        feeBps: partnerFeeBps && partnerAddress ? Number(partnerFeeBps) : defaultFeeBps,
+      });
+
+      const res = await walletClient.sendTransaction({
+        chain: fromChain,
+        data: tx.data as `0x${string}`,
+        account: tx.from as `0x${string}`,
+        to: tx.to as `0x${string}`,
+        gas: BigInt(tx.gasLimit),
+        value: tx.value !== undefined ? BigInt(tx.value) : undefined,
+      });
+      setThrottle(1);
+
+      return res;
+    },
+    {
+      onError: error => {
+        if (error instanceof Error) {
+          showToast({ text: getViemErrorMessage(error), type: 'error' });
+        } else {
+          console.error(error);
+        }
+      },
+      onSettled: () => {
+        setIsLoading(false);
+        setThrottle(0.01);
+      },
+      onSuccess: async hash => {
+        const explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
+
+        showToast({
+          text: 'Your swap has been confirmed. Please stand by.',
+          type: 'info',
+        });
+
+        await publicClient.waitForTransactionReceipt({ hash });
+
+        showToast({
+          type: 'success',
+          text: 'Your swap has confirmed. It may take a while until it confirms on the blockchain.',
+          ...(explorerLink ? { link: { text: 'View Transaction', href: explorerLink } } : {}),
+        });
+
+        refetchFromBalance();
+        refetchToBalance();
+        refetchFromTokenBalances();
+        refetchToTokenBalances();
+        setValue(SwapFormKey.FromAmount, '');
+      },
+    }
+  );
+
+  const executeSwap = async () => {
+    if (!fromToken || !toToken) throw new Error('Tokens are missing');
+    if (!address) throw new Error('fromAddress is missing');
+
+    setThrottle(0.25);
+    setIsLoading(true);
+    mutation.mutate();
+  };
+
+  return { executeSwap, isLoading };
+};
+
+export { useExecuteSwap };

--- a/packages/frontend/src/hooks/useExecuteSwap.tsx
+++ b/packages/frontend/src/hooks/useExecuteSwap.tsx
@@ -105,7 +105,14 @@ const useExecuteSwap = () => {
         setThrottle(0.01);
       },
       onSuccess: async hash => {
-        const explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
+        const isJump = fromChain.id !== toChain.id;
+        let explorerLink: string | undefined;
+
+        if (isJump) {
+          explorerLink = `https://layerzeroscan.com/tx/${hash}`;
+        } else {
+          explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
+        }
 
         showToast({
           text: 'Your swap has been confirmed. Please stand by.',


### PR DESCRIPTION
It's quite difficult to work with CreateSwap, it got quite bloated. The new swap modal (#453) also requires some preliminary refactors, hence this PR.

- Creates new useExecuteSwap hook so the execution can be reused and moves over the related logic.
- Creates new useDepositMax hook and moves over the related logic.

### Testing
- [x] Quotes work
- [x] Same chain swap works
- [x] Cross-chain swap works
- [x] Animation works
- [x] No noticeable change to the UI