### PR TITLE
feat(frontend): add referral modal

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { SpaceTravelCanvas } from './space-travel/SpaceTravelCanvas';
 import { RecentWarps } from './components/RecentWarps/RecentWarps';
 import { Dashboard } from 'src/pages/Dashboard';
 import { useReferrer } from 'src/hooks/useReferrer';
+import { ReferralModal } from './modals/ReferralModal/ReferralModal';
 
 const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
   return (
@@ -46,6 +47,7 @@ const App = () => {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="*" element={<Home />} />
         </Routes>
+        <ReferralModal />
       </Layout>
     </AppProvider>
   );

--- a/packages/frontend/src/AppProvider.tsx
+++ b/packages/frontend/src/AppProvider.tsx
@@ -11,6 +11,7 @@ import { WagmiProvider } from './providers/WagmiProvider';
 import { TokensProvider } from './providers/TokensProvider';
 import { SpaceTravelProvider } from './providers/SpaceTravelProvider';
 import { SwapHistoryProvider } from './providers/SwapHistoryProvider';
+import { ReferralModalProvider } from './providers/ReferralModalProvider';
 
 const QueryProvider = QueryClientProvider;
 const queryClient = new QueryClient();
@@ -25,8 +26,10 @@ export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
               <SwapFormProvider>
                 <TokensProvider>
                   <SwapHistoryProvider>
-                    <SpaceTravelProvider>{children}</SpaceTravelProvider>
-                    <CustomToastContainer />
+                    <ReferralModalProvider>
+                      <SpaceTravelProvider>{children}</SpaceTravelProvider>
+                      <CustomToastContainer />
+                    </ReferralModalProvider>
                   </SwapHistoryProvider>
                 </TokensProvider>
               </SwapFormProvider>

--- a/packages/frontend/src/components/Footer/Footer.tsx
+++ b/packages/frontend/src/components/Footer/Footer.tsx
@@ -3,8 +3,11 @@ import { Footer as FooterComponent } from '@sifi/shared-ui';
 import { ReactComponent as Logo } from '../../assets/logoWhite.svg';
 import { texts } from 'src/texts';
 import { Link } from '../Link/Link';
+import { useReferralModal } from 'src/providers/ReferralModalProvider';
 
 const Footer: FunctionComponent = () => {
+  const { openReferralModal } = useReferralModal();
+
   const columnLinks = [
     [
       {
@@ -15,6 +18,11 @@ const Footer: FunctionComponent = () => {
         href: 'https://docs.sifi.org',
         title: 'Docs',
         external: true,
+      },
+      {
+        title: 'Refer',
+        href: '#',
+        onClick: () => openReferralModal(),
       },
     ],
     [

--- a/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
+++ b/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
@@ -4,6 +4,7 @@ import { useAccount, useDisconnect, useEnsName, useNetwork } from 'wagmi';
 import { formatAddress, formatEnsName } from 'src/utils';
 import { Link } from '../Link/Link';
 import { useSwapHistory } from 'src/providers/SwapHistoryProvider';
+import { useReferralModal } from 'src/providers/ReferralModalProvider';
 
 const HeaderMenu: FunctionComponent = () => {
   const { address, isConnected } = useAccount();
@@ -12,6 +13,7 @@ const HeaderMenu: FunctionComponent = () => {
   const { disconnect } = useDisconnect();
   const { icon, text } = useWalletBranding();
   const { toggleHistoryModal } = useSwapHistory();
+  const { openReferralModal } = useReferralModal();
 
   if (!address || !isConnected) return null;
 
@@ -25,6 +27,10 @@ const HeaderMenu: FunctionComponent = () => {
     {
       title: 'Dashboard',
       href: '/dashboard',
+    },
+    {
+      title: 'Refer',
+      onClick: () => openReferralModal(),
     },
     {
       title: 'Disconnect Wallet',

--- a/packages/frontend/src/config.ts
+++ b/packages/frontend/src/config.ts
@@ -2,5 +2,6 @@ const { REACT_APP_WALLET_CONNECT_PROJECT_ID, REACT_APP_DEFAULT_FEE_BPS } = impor
 
 const walletConnectProjectId = REACT_APP_WALLET_CONNECT_PROJECT_ID;
 const defaultFeeBps = REACT_APP_DEFAULT_FEE_BPS ? Number(REACT_APP_DEFAULT_FEE_BPS) : undefined;
+const defaultReferralFeeBps = 40;
 
-export { walletConnectProjectId, defaultFeeBps };
+export { walletConnectProjectId, defaultFeeBps, defaultReferralFeeBps };

--- a/packages/frontend/src/hooks/useExecuteSwap.tsx
+++ b/packages/frontend/src/hooks/useExecuteSwap.tsx
@@ -13,7 +13,7 @@ import { localStorageKeys } from 'src/utils/localStorageKeys';
 import { usePermit2 } from 'src/hooks/usePermit2';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { useSpaceTravel } from 'src/providers/SpaceTravelProvider';
-import { defaultFeeBps } from 'src/config';
+import { defaultFeeBps, defaultReferralFeeBps } from 'src/config';
 import { useSwapToast } from './useSwapToast';
 import { useSwapHistory } from 'src/providers/SwapHistoryProvider';
 
@@ -49,6 +49,11 @@ const useExecuteSwap = () => {
 
       const partnerAddress = localStorage.getItem(localStorageKeys.REFFERRER_ADDRESS);
       const partnerFeeBps = localStorage.getItem(localStorageKeys.REFERRER_FEE_BPS);
+      let feeBps = defaultFeeBps;
+
+      if (partnerAddress) {
+        feeBps = partnerFeeBps ? Number(partnerFeeBps) : defaultReferralFeeBps;
+      }
 
       const permit =
         quote.approveAddress && quote.permit2Address
@@ -66,7 +71,7 @@ const useExecuteSwap = () => {
         quote,
         permit,
         partner: partnerAddress || undefined,
-        feeBps: partnerFeeBps && partnerAddress ? Number(partnerFeeBps) : defaultFeeBps,
+        feeBps,
       });
 
       const res = await walletClient.sendTransaction({

--- a/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
+++ b/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
@@ -47,7 +47,7 @@ const ReferralModal: FunctionComponent = () => {
       className="pb-0"
     >
       <p className="font-light mb-4 dark:text-smoke text-new-black">
-        Refer someone to Sifi and earn 1% of their trading fees.
+        Refer someone to Sifi and earn 0.2% of their trading fees.
       </p>
 
       {address && <div className="select-all break-words text-md">{referralLink}</div>}

--- a/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
+++ b/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
@@ -1,0 +1,67 @@
+import { Modal, showToast } from '@sifi/shared-ui';
+import { FunctionComponent } from 'react';
+import { Button } from 'src/components/Button';
+import { ConnectWallet } from 'src/components/ConnectWallet/ConnectWallet';
+import { useReferralModal } from 'src/providers/ReferralModalProvider';
+import { useAccount } from 'wagmi';
+
+const ReferralModal: FunctionComponent = () => {
+  const { isReferralModalOpen, closeReferralModal } = useReferralModal();
+  const { address } = useAccount();
+
+  const generateReferralLink = () => {
+    if (!address) return null;
+
+    const feeBps = 20;
+
+    return `https://sifi.org/#/${address}${feeBps}`;
+  };
+
+  const referralLink = generateReferralLink();
+
+  const handleButtonClick = () => {
+    if (!referralLink) {
+      showToast({ text: 'Referral link is missing.', type: 'error' });
+      return;
+    }
+
+    if (navigator.share) {
+      // Mobile
+      navigator.share({
+        title: 'Sifi Referral Link',
+        text: 'Check out Sifi.org! ',
+        url: referralLink,
+      });
+    } else {
+      // Desktop
+      navigator.clipboard.writeText(referralLink);
+      showToast({ text: 'Referral link copied to clipboard!', type: 'info' });
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isReferralModalOpen}
+      handleClose={closeReferralModal}
+      title="Refer"
+      className="pb-0"
+    >
+      <p className="font-light mb-4 dark:text-smoke text-new-black">
+        Refer someone to Sifi and earn 1% of their trading fees.
+      </p>
+
+      {address && <div className="select-all break-words text-md">{referralLink}</div>}
+
+      <div className="flex justify-center my-8">
+        {address ? (
+          <Button role="button" onClick={handleButtonClick}>
+            Copy Referral Link
+          </Button>
+        ) : (
+          <ConnectWallet />
+        )}
+      </div>
+    </Modal>
+  );
+};
+export { ReferralModal };

--- a/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
+++ b/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
@@ -22,14 +22,14 @@ const ReferralModal: FunctionComponent = () => {
   const handleButtonClick = () => {
     if (!referralLink) {
       showToast({ text: 'Referral link is missing.', type: 'error' });
+
       return;
     }
 
     if (navigator.share) {
       // Mobile
       navigator.share({
-        title: 'Sifi Referral Link',
-        text: 'Check out Sifi.org! ',
+        title: 'Your Sifi Referral Link',
         url: referralLink,
       });
     } else {
@@ -38,6 +38,8 @@ const ReferralModal: FunctionComponent = () => {
       showToast({ text: 'Referral link copied to clipboard!', type: 'info' });
     }
   };
+
+  const buttonLabel = !!navigator.share ? 'Share Referral Link' : 'Copy Referral Link';
 
   return (
     <Modal
@@ -55,7 +57,7 @@ const ReferralModal: FunctionComponent = () => {
       <div className="flex justify-center my-8">
         {address ? (
           <Button role="button" onClick={handleButtonClick}>
-            Copy Referral Link
+            {buttonLabel}
           </Button>
         ) : (
           <ConnectWallet />

--- a/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
+++ b/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
@@ -12,7 +12,7 @@ const ReferralModal: FunctionComponent = () => {
   const generateReferralLink = () => {
     if (!address) return null;
 
-    const feeBps = 20;
+    const feeBps = 200;
 
     return `https://sifi.org/#/${address}${feeBps}`;
   };

--- a/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
+++ b/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
@@ -12,9 +12,7 @@ const ReferralModal: FunctionComponent = () => {
   const generateReferralLink = () => {
     if (!address) return null;
 
-    const feeBps = 200;
-
-    return `https://sifi.org/#/${address}${feeBps}`;
+    return `https://sifi.org/#/r/${address}`;
   };
 
   const referralLink = generateReferralLink();

--- a/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
+++ b/packages/frontend/src/modals/ReferralModal/ReferralModal.tsx
@@ -50,7 +50,7 @@ const ReferralModal: FunctionComponent = () => {
         Refer someone to Sifi and earn 0.2% of their trading fees.
       </p>
 
-      {address && <div className="select-all break-words text-md">{referralLink}</div>}
+      {address && <div className="select-all break-all text-md">{referralLink}</div>}
 
       <div className="flex justify-center my-8">
         {address ? (

--- a/packages/frontend/src/providers/ReferralModalProvider.tsx
+++ b/packages/frontend/src/providers/ReferralModalProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, useState, useContext } from 'react';
+
+interface ReferralModalContextProps {
+  isReferralModalOpen: boolean;
+  openReferralModal: () => void;
+  closeReferralModal: () => void;
+}
+
+const ReferralModalContext = createContext<ReferralModalContextProps>({
+  isReferralModalOpen: false,
+  openReferralModal: () => {},
+  closeReferralModal: () => {},
+});
+
+export const ReferralModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [isReferralModalOpen, setIsReferralModalOpen] = useState(false);
+
+  const openReferralModal = () => setIsReferralModalOpen(true);
+  const closeReferralModal = () => setIsReferralModalOpen(false);
+
+  return (
+    <ReferralModalContext.Provider
+      value={{ isReferralModalOpen, openReferralModal, closeReferralModal }}
+    >
+      {children}
+    </ReferralModalContext.Provider>
+  );
+};
+
+export const useReferralModal = () => useContext(ReferralModalContext);


### PR DESCRIPTION
- Adds a referral modal. 
- Places links in the Menu and in the footer.
- The URL does not contain `feeBps`, sticking to default. UI shows 1% because 50% goes to the protocol.
- Uses context to keep track of the state as we have the modal in multiple places.
- Triggers the share action on mobile, copies to clipboard on desktop.
- Shows toast after successful copy on desktop.
- Shows connect wallet if the user is not connected.

### Testing
- [x] Sharing works on mobile using MetaMask
- [x] Copy works on desktop
- [x] Referral address and fee set in localstorage after using the link
- [x] Connect wallet state works

### Screenshot 
![image](https://github.com/sifiorg/sifi/assets/128667801/02b67bb4-089f-4191-bbbb-4ea681a21ac6)

