### PR TITLE
feat(frontend): add nav links

### DIFF
--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -5,10 +5,23 @@ import HeaderMenu from '../HeaderMenu/HeaderMenu';
 
 const Logo = () => <LogoWhite alt="Sifi logo" className="max-h-[2rem]" />;
 
+const navLinks = [
+  {
+    href: 'https://discord.gg/sXDKcUYnU8',
+    title: 'Discord',
+    external: true,
+  },
+  {
+    href: 'https://docs.sifi.org',
+    title: 'Docs',
+    external: true,
+  },
+];
+
 const Header: FunctionComponent = () => {
   return (
     <>
-      <Navbar Logo={Logo}>
+      <Navbar Logo={Logo} navLinks={navLinks}>
         <HeaderMenu />
       </Navbar>
     </>


### PR DESCRIPTION
Re-adds the Discord and Docs links to the header, to make it easier for users to find them. 

Tested by clicking on them.

![image](https://github.com/sifiorg/sifi/assets/128667801/d74c0026-4abb-47b4-9dfc-8eab55da99b3)
