### PR TITLE
feat(frontend): use LayerZero Scan for jumps

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -129,7 +129,13 @@ const CreateSwap = () => {
         setThrottle(0.01);
       },
       onSuccess: async hash => {
-        const explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
+        const isJump = fromChain.id !== toChain.id;
+        let explorerLink: string | undefined;
+        if (isJump) {
+          explorerLink = `https://layerzeroscan.com/tx/${hash}`;
+        } else {
+          explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
+        }
 
         showToast({
           text: 'Your swap has been confirmed. Please stand by.',


### PR DESCRIPTION
Use LayerZero Scan explorer link for Jumps, as the native chain explorer only shows half the picture.

### Testing
- [x] On-chain swap uses the native explorer
- [x] Cross-chain swap uses the LayerZero Scan