### PR TITLE
feat(frontend): do not auto close success toast

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -142,6 +142,7 @@ const CreateSwap = () => {
           type: 'success',
           text: 'Your swap has confirmed. It may take a while until it confirms on the blockchain.',
           ...(explorerLink ? { link: { text: 'View Transaction', href: explorerLink } } : {}),
+          autoClose: false,
         });
 
         refetchFromBalance();


### PR DESCRIPTION
Adds `autoClose: false` so that the success TX link does not disappear, as this is the only way for users to track Jumps.

Toasts will get significantly more improvement in #486, this is just a quick fix.