### PR TITLE
fix(frontend): temp "loading" Toast type

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.0.12",
     "@sifi/sdk": "~1.11.0",
-    "@sifi/shared-ui": "^1.11.5",
+    "@sifi/shared-ui": "^1.11.7",
     "@tanstack/react-query": "^4.13.0",
     "@types/three": "^0.127.1",
     "@uniswap/permit2-sdk": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ~1.11.0
         version: link:../sdk
       '@sifi/shared-ui':
-        specifier: ^1.11.5
-        version: 1.11.5(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12)
+        specifier: ^1.11.7
+        version: 1.11.7(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12)
       '@tanstack/react-query':
         specifier: ^4.13.0
         version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
@@ -6150,7 +6150,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
       '@radix-ui/number': 1.0.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
@@ -6277,7 +6277,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.0.28)(react@18.2.0)
       '@radix-ui/react-direction': 1.0.1(@types/react@18.0.28)(react@18.2.0)
@@ -6666,8 +6666,8 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
-  /@sifi/shared-ui@1.11.5(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12):
-    resolution: {integrity: sha512-bc2LCYQok1lBTM7xNOnNFSKEge0I0tr08kua7FGPe5kmbPS5/KsjZ1KULSZvUkhudKey8mEPbMOhlmJfLpTaEA==}
+  /@sifi/shared-ui@1.11.7(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12):
+    resolution: {integrity: sha512-XEhVnHEXQlgDQII1cfmFEuzgtd39NkrMVopZMlRGtfQq2Mpb5+K8EfsW6X3wlLRMpSDgoyTWzOZUFSuCvwabyw==}
     peerDependencies:
       '@headlessui/react': ^1.7.3
       date-fns: 2.29.3
@@ -11489,7 +11489,7 @@ packages:
   /babel-plugin-macros@2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
       cosmiconfig: 6.0.0
       resolve: 1.22.4
     dev: true
@@ -14345,7 +14345,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
       aria-query: 5.3.0
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1


### PR DESCRIPTION
Fixed the `type` issue by omitting `type` from `ToastOptions` in the latest `shared-ui` build. This PR fixes the TypeScript error so we can continue deploying.

~Can't figure out why the `loading` prop is not working. `ToastType` clearly contains it and everything in the shared-ui lib looks fine. Typescript accepts it when passed directly to `Toast`, but not when used in `showToast`. The UI works as expected. This PR temporary fixes it so that we can continue deploying.~

### Testing
- [x] Works locally
- [ ] Fleek - deploy previews stopped running, can't test