### PR TITLE
feat(frontend): set fee bps to 40 with partner address only

### DIFF
--- a/packages/frontend/src/config.ts
+++ b/packages/frontend/src/config.ts
@@ -2,5 +2,6 @@ const { REACT_APP_WALLET_CONNECT_PROJECT_ID, REACT_APP_DEFAULT_FEE_BPS } = impor
 
 const walletConnectProjectId = REACT_APP_WALLET_CONNECT_PROJECT_ID;
 const defaultFeeBps = REACT_APP_DEFAULT_FEE_BPS ? Number(REACT_APP_DEFAULT_FEE_BPS) : undefined;
+const defaultReferralFeeBps = 40;
 
-export { walletConnectProjectId, defaultFeeBps };
+export { walletConnectProjectId, defaultFeeBps, defaultReferralFeeBps };

--- a/packages/frontend/src/hooks/useExecuteSwap.tsx
+++ b/packages/frontend/src/hooks/useExecuteSwap.tsx
@@ -13,7 +13,7 @@ import { localStorageKeys } from 'src/utils/localStorageKeys';
 import { usePermit2 } from 'src/hooks/usePermit2';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { useSpaceTravel } from 'src/providers/SpaceTravelProvider';
-import { defaultFeeBps } from 'src/config';
+import { defaultFeeBps, defaultReferralFeeBps } from 'src/config';
 import { useSwapToast } from './useSwapToast';
 import { useSwapHistory } from 'src/providers/SwapHistoryProvider';
 
@@ -49,6 +49,11 @@ const useExecuteSwap = () => {
 
       const partnerAddress = localStorage.getItem(localStorageKeys.REFFERRER_ADDRESS);
       const partnerFeeBps = localStorage.getItem(localStorageKeys.REFERRER_FEE_BPS);
+      let feeBps = defaultFeeBps;
+
+      if (partnerAddress) {
+        feeBps = partnerFeeBps ? Number(partnerFeeBps) : defaultReferralFeeBps;
+      }
 
       const permit =
         quote.approveAddress && quote.permit2Address
@@ -66,7 +71,7 @@ const useExecuteSwap = () => {
         quote,
         permit,
         partner: partnerAddress || undefined,
-        feeBps: partnerFeeBps && partnerAddress ? Number(partnerFeeBps) : defaultFeeBps,
+        feeBps,
       });
 
       const res = await walletClient.sendTransaction({


### PR DESCRIPTION
If only `referralAddress` in localstorage, due to the user being referred via a URL without a `feeBps` specified in it, use `feeBps` of `40` when executing a swap.