### PR TITLE
chore(frontend): upgrade @sifi/shared-ui to 2.0.1

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.1.1",
     "@sifi/sdk": "~1.12.0",
-    "@sifi/shared-ui": "^1.11.7",
+    "@sifi/shared-ui": "^2.0.1",
     "@tanstack/react-query": "^4.13.0",
     "@types/three": "^0.127.1",
     "@uniswap/permit2-sdk": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ~1.12.0
         version: link:../sdk
       '@sifi/shared-ui':
-        specifier: ^1.11.7
-        version: 1.11.7(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12)
+        specifier: ^2.0.1
+        version: 2.0.1(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12)
       '@tanstack/react-query':
         specifier: ^4.13.0
         version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
@@ -3536,6 +3536,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
+    dev: true
 
   /@babel/runtime@7.23.6:
     resolution: {integrity: sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==}
@@ -6674,8 +6675,8 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
-  /@sifi/shared-ui@1.11.7(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12):
-    resolution: {integrity: sha512-XEhVnHEXQlgDQII1cfmFEuzgtd39NkrMVopZMlRGtfQq2Mpb5+K8EfsW6X3wlLRMpSDgoyTWzOZUFSuCvwabyw==}
+  /@sifi/shared-ui@2.0.1(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12):
+    resolution: {integrity: sha512-/zxhQRlyGLAS2ADPh8zGAMxIpKrJtyeDNQRN7dBse6P4ETgX5InkXpjLIbgSDjczngb+HabnE3vBa5/H9KhM2g==}
     peerDependencies:
       '@headlessui/react': ^1.7.3
       date-fns: 2.29.3
@@ -14374,7 +14375,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
       aria-query: 5.3.0
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
@@ -16698,7 +16699,7 @@ packages:
   /history@5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
     dev: false
 
   /hmac-drbg@1.0.1:
@@ -21930,6 +21931,7 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: true
 
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}


### PR DESCRIPTION
Upgrades shared-ui to the latest version.

### Testing
- HeaderMenu no longer remains open when Shift History is opened.
- Builds correctly.