### PR TITLE
feat(frontend): display Connect Wallet button in Header

### DIFF
--- a/packages/frontend/src/components/Button/Button.tsx
+++ b/packages/frontend/src/components/Button/Button.tsx
@@ -1,9 +1,11 @@
 import { ButtonHTMLAttributes, FunctionComponent } from 'react';
 import { Spinner } from '../Spinner/Spinner';
 
+type ButtonSizes = 'large' | 'normal' | 'small';
+
 type ButtonProps = {
   isLoading?: boolean;
-  size?: 'large' | 'normal' | 'small';
+  size?: ButtonSizes;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const Button: FunctionComponent<ButtonProps> = ({
@@ -30,3 +32,4 @@ const Button: FunctionComponent<ButtonProps> = ({
 };
 
 export { Button };
+export type { ButtonSizes };

--- a/packages/frontend/src/components/Button/Button.tsx
+++ b/packages/frontend/src/components/Button/Button.tsx
@@ -1,7 +1,6 @@
 import { ButtonHTMLAttributes, FunctionComponent } from 'react';
 import { Spinner } from '../Spinner/Spinner';
-
-type ButtonSizes = 'large' | 'normal' | 'small';
+import { ButtonSizes } from './Button.types';
 
 type ButtonProps = {
   isLoading?: boolean;
@@ -32,4 +31,3 @@ const Button: FunctionComponent<ButtonProps> = ({
 };
 
 export { Button };
-export type { ButtonSizes };

--- a/packages/frontend/src/components/Button/Button.types.ts
+++ b/packages/frontend/src/components/Button/Button.types.ts
@@ -1,0 +1,3 @@
+type ButtonSizes = 'large' | 'normal' | 'small';
+
+export type { ButtonSizes };

--- a/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
@@ -3,7 +3,7 @@ import { Modal, showToast, WalletOption, useWalletBranding } from '@sifi/shared-
 import useConnectWallet from 'src/hooks/useConnectWallet';
 import { type SupportedWallet } from 'src/connectors';
 import { getViemErrorMessage } from 'src/utils';
-import { Button } from '../Button';
+import { Button, ButtonSizes } from '../Button';
 
 const supportedWallets: SupportedWallet[] = ['injected', 'coinbase', 'walletconnect'];
 
@@ -42,13 +42,13 @@ const ConnectWalletModal: FunctionComponent<ConnectWalletModalProps> = ({
   );
 };
 
-const ConnectWallet: FunctionComponent = () => {
+const ConnectWallet: FunctionComponent<{ size?: ButtonSizes }> = ({ size = 'normal' }) => {
   const { isLoading } = useConnectWallet();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   return (
     <>
-      <Button type="button" isLoading={isLoading} onClick={() => setIsModalOpen(true)}>
+      <Button type="button" size={size} isLoading={isLoading} onClick={() => setIsModalOpen(true)}>
         Connect Wallet
       </Button>
       <ConnectWalletModal isOpen={isModalOpen} closeModal={() => setIsModalOpen(false)} />

--- a/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
@@ -3,7 +3,8 @@ import { Modal, showToast, WalletOption, useWalletBranding } from '@sifi/shared-
 import useConnectWallet from 'src/hooks/useConnectWallet';
 import { type SupportedWallet } from 'src/connectors';
 import { getViemErrorMessage } from 'src/utils';
-import { Button, ButtonSizes } from '../Button';
+import { Button } from '../Button';
+import { ButtonSizes } from '../Button/Button.types';
 
 const supportedWallets: SupportedWallet[] = ['injected', 'coinbase', 'walletconnect'];
 

--- a/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
+++ b/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
@@ -5,6 +5,7 @@ import { formatAddress, formatEnsName } from 'src/utils';
 import { Link } from '../Link/Link';
 import { useSwapHistory } from 'src/providers/SwapHistoryProvider';
 import { useReferralModal } from 'src/providers/ReferralModalProvider';
+import { ConnectWallet } from '../ConnectWallet/ConnectWallet';
 
 const HeaderMenu: FunctionComponent = () => {
   const { address, isConnected } = useAccount();
@@ -15,7 +16,12 @@ const HeaderMenu: FunctionComponent = () => {
   const { toggleHistoryModal } = useSwapHistory();
   const { openReferralModal } = useReferralModal();
 
-  if (!address || !isConnected) return null;
+  if (!address || !isConnected)
+    return (
+      <div className="hidden md:block">
+        <ConnectWallet size="small" />
+      </div>
+    );
 
   const label = ensName ? formatEnsName(ensName) : formatAddress(address);
 


### PR DESCRIPTION
Adds the Connect Wallet button to the header as per [this request on Discord](https://discord.com/channels/1032578356241244160/1164402982251675649/1196732960372695081). For this to work, had to export the `ButtonSizes` type from Button.

### Testing
- [x] Wallet connection works
- [x] Does not show on mobile

![image](https://github.com/sifiorg/sifi/assets/128667801/c7fc2931-67c8-450a-babe-f35fb9345c00)
