### PR TITLE
style(frontend): fix medium breakpoint width

### DIFF
--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -5,7 +5,7 @@ import { Audits } from '../Audits/Audits';
 
 const Hero = () => (
   <div className="mx-auto flex w-full max-w-[67rem] min-h-[90vh] flex-wrap justify-center items-center px-4 py-4 sm:px-8 lg:px-16 ">
-    <div className="w-full md:w-[50%] relative">
+    <div className="w-full relative">
       <h1 className="text-flashbang-white font-display mb-0 pb-0 text-center text-[1.875rem] sm:text-[2.25rem]">
         Swap
       </h1>


### PR DESCRIPTION
At certain medium screen sizes, the app got too squished. This one liner fixes this.

### Before/after
![image](https://github.com/sifiorg/sifi/assets/128667801/72cebc4c-553e-4789-9ab2-429bab4d3e5f)
 