### PR TITLE
feat(frontend): add balance loading state to TokenSelector

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.1.1",
     "@sifi/sdk": "~1.12.0",
-    "@sifi/shared-ui": "^2.0.1",
+    "@sifi/shared-ui": "^2.2.0",
     "@tanstack/react-query": "^4.13.0",
     "@types/three": "^0.127.1",
     "@uniswap/permit2-sdk": "^1.2.0",

--- a/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
@@ -23,7 +23,7 @@ const TokenSelector: FunctionComponent<{
   const fetchTokenByAddress = type === 'from' ? fetchFromTokenByAddress : fetchToTokenByAddress;
   const { setValue, watch } = useFormContext();
   const selectedToken = getTokenBySymbol(watch(selectId), tokens);
-  const { balanceMapsByChain } = useWalletBalances();
+  const { balanceMapsByChain, isLoading: isLoadingBalances } = useWalletBalances();
   const balanceMap = balanceMapsByChain?.[chain.id] || null;
 
   const handleSelectToken = (newTokenAddress: `0x${string}`) => {
@@ -62,6 +62,7 @@ const TokenSelector: FunctionComponent<{
       options={formattedTokens}
       isOpen={isOpen}
       onClose={close}
+      isLoadingBalances={isLoadingBalances}
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       onSelect={tokenId => handleSelectToken(tokenId as `0x${string}`)}
       onTokenAddressInput={fetchTokenByAddress}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ~1.12.0
         version: link:../sdk
       '@sifi/shared-ui':
-        specifier: ^2.0.1
-        version: 2.0.1(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12)
+        specifier: ^2.2.0
+        version: 2.2.0(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12)
       '@tanstack/react-query':
         specifier: ^4.13.0
         version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
@@ -3531,13 +3531,6 @@ packages:
       regenerator-runtime: 0.14.0
     dev: true
 
-  /@babel/runtime@7.22.6:
-    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.11
-    dev: true
-
   /@babel/runtime@7.23.6:
     resolution: {integrity: sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==}
     engines: {node: '>=6.9.0'}
@@ -6675,8 +6668,8 @@ packages:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
-  /@sifi/shared-ui@2.0.1(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12):
-    resolution: {integrity: sha512-/zxhQRlyGLAS2ADPh8zGAMxIpKrJtyeDNQRN7dBse6P4ETgX5InkXpjLIbgSDjczngb+HabnE3vBa5/H9KhM2g==}
+  /@sifi/shared-ui@2.2.0(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.4.12):
+    resolution: {integrity: sha512-44E1DNCbUWMXw20XqjJvxdj/RZjhf48vAk6ptP4jtzUfs/uriyUuGyuOI4jgu4a8Lgsqy4ZFpifOo/XMnUswnw==}
     peerDependencies:
       '@headlessui/react': ^1.7.3
       date-fns: 2.29.3
@@ -8262,7 +8255,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.22.10
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -20992,7 +20985,7 @@ packages:
     resolution: {integrity: sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.23.6
     dev: true
 
   /posix-character-classes@0.1.1:


### PR DESCRIPTION
- Adds the loading state for token balances.
- Only display the loading state on initial fetch. Would be annoying UX for refetches to hide the balances.

### Testing
- [x] Loading state at initial fetch
- [x] No loading state during refetching
- [x] No loading state if the wallet is not connected

### Video
https://github.com/sifiorg/sifi/assets/128667801/caff03bd-4ae9-4b0e-ab58-0d40b4ec5220