### PR TITLE
refactor(frontend): separate GasFee and SwapPath components

### DIFF
--- a/packages/frontend/src/components/SwapDetails/GasFee.tsx
+++ b/packages/frontend/src/components/SwapDetails/GasFee.tsx
@@ -1,0 +1,39 @@
+import { Quote } from '@sifi/sdk';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ReactComponent as GasIcon } from 'src/assets/icons/gas.svg';
+import { useGasFee } from 'src/hooks/useGasFee';
+
+type GasFeeProps = {
+  quote: Quote | null;
+};
+
+const GasFee: React.FC<GasFeeProps> = ({ quote }) => {
+  const { gasFeeEstimateUsd } = useGasFee(quote);
+
+  return (
+    <div className="relative flex items-center">
+      <div className="absolute">
+        <AnimatePresence>
+          {gasFeeEstimateUsd && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.1 }}
+              className="flex items-center text-sm"
+            >
+              <GasIcon className="fill-smoke w-4 h-4 mr-2" />
+              <span className="min-w-[7rem]">${gasFeeEstimateUsd}</span>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+      {/* Placeholder to maintain layout */}
+      <div className="w-4 h-4 mr-2 opacity-0">
+        <GasIcon />
+      </div>
+    </div>
+  );
+};
+
+export { GasFee };

--- a/packages/frontend/src/components/SwapDetails/SwapDetails.tsx
+++ b/packages/frontend/src/components/SwapDetails/SwapDetails.tsx
@@ -1,148 +1,6 @@
-import { ReactComponent as GasIcon } from 'src/assets/icons/gas.svg';
-import { useGasFee } from 'src/hooks/useGasFee';
-import { motion, AnimatePresence } from 'framer-motion';
 import { useQuote } from 'src/hooks/useQuote';
-import { EitherQuoteSifiAction, Quote } from '@sifi/sdk';
-import { ReactComponent as UniswapIcon } from 'src/assets/bridges/uniswap.svg';
-import { ReactComponent as CurveIcon } from 'src/assets/bridges/curve.svg';
-import { ReactComponent as StargateIcon } from 'src/assets/bridges/stargate.svg';
-import { ReactComponent as ArrowRight } from 'src/assets/arrow-right.svg';
-
-type GasFeeProps = {
-  quote: Quote | null;
-};
-
-type PathProps = {
-  quote: Quote | null;
-};
-
-type StepDetails = {
-  [key: string]: { icon: JSX.Element; name: string };
-};
-
-type Step = {
-  icon: JSX.Element;
-  name: string;
-};
-
-const iconClassName = 'w-4 h-4 border-smoke border rounded-full';
-
-const stepDetails: StepDetails = {
-  uniswap: { icon: <UniswapIcon className={iconClassName} />, name: 'Uniswap' },
-  stargate: { icon: <StargateIcon className={iconClassName} />, name: 'Stargate' },
-  curve: { icon: <CurveIcon className={iconClassName} />, name: 'Curve' },
-};
-
-type StepInfo = {
-  icon: JSX.Element;
-  name: string;
-};
-
-const getStepDetailsFromAction = (action: EitherQuoteSifiAction): StepInfo | null => {
-  if ('exchange' in action) {
-    const exchange = action.exchange.toLowerCase();
-
-    for (let key in stepDetails) {
-      const regex = new RegExp(key, 'i');
-
-      if (regex.test(exchange)) {
-        const detail = stepDetails[key];
-
-        if (detail) {
-          return {
-            icon: detail.icon,
-            name: detail.name,
-          };
-        }
-      }
-    }
-  }
-  return null;
-};
-
-const GasFee: React.FC<GasFeeProps> = ({ quote }) => {
-  const { gasFeeEstimateUsd } = useGasFee(quote);
-
-  return (
-    <div className="relative flex items-center">
-      <div className="absolute">
-        <AnimatePresence>
-          {gasFeeEstimateUsd && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.1 }}
-              className="flex items-center text-sm"
-            >
-              <GasIcon className="fill-smoke w-4 h-4 mr-2" />
-              <span className="min-w-[7rem]">${gasFeeEstimateUsd}</span>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-      {/* Placeholder to maintain layout */}
-      <div className="w-4 h-4 mr-2 opacity-0">
-        <GasIcon />
-      </div>
-    </div>
-  );
-};
-
-const Path: React.FC<PathProps> = ({ quote }) => {
-  if (!quote || !('element' in quote.source.quote) || !quote.source.quote.element.actions) {
-    return null;
-  }
-
-  let steps: Step[] = [];
-
-  quote.source.quote.element.actions.forEach(action => {
-    if (action.type === 'split') {
-      action.parts.forEach(part => {
-        part.actions.forEach(partAction => {
-          const step = getStepDetailsFromAction(partAction);
-
-          if (!step) return;
-
-          steps.push(step);
-        });
-      });
-    } else {
-      const step = getStepDetailsFromAction(action);
-
-      if (!step) return;
-
-      steps.push(step);
-    }
-  });
-
-  // The UI can only fit 6 steps
-  steps = steps.slice(-6);
-
-  return (
-    <AnimatePresence>
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.1 }}
-        className="flex items-center"
-      >
-        {steps.map((step, index) => (
-          <div key={index}>
-            <div className="flex text-sm items-center">
-              {step.icon && <div className="mx-1">{step.icon}</div>}
-              {step.name && steps.length < 4 && (
-                <div className="hidden xs:block ml-1">{step.name}</div>
-              )}
-              {step.icon && index !== steps.length - 1 && <ArrowRight className="w-4 mx-1" />}
-            </div>
-          </div>
-        ))}
-      </motion.div>
-    </AnimatePresence>
-  );
-};
+import { GasFee } from './GasFee';
+import { SwapPath } from '../SwapPath/SwapPath';
 
 const SwapDetails = () => {
   const { quote } = useQuote();
@@ -152,11 +10,11 @@ const SwapDetails = () => {
       {quote && (
         <>
           <GasFee quote={quote} />
-          <Path quote={quote} />
+          <SwapPath quote={quote} />
         </>
       )}
     </div>
   );
 };
 
-export { SwapDetails, GasFee, Path };
+export { SwapDetails };

--- a/packages/frontend/src/components/SwapDetails/SwapDetails.tsx
+++ b/packages/frontend/src/components/SwapDetails/SwapDetails.tsx
@@ -2,11 +2,19 @@ import { ReactComponent as GasIcon } from 'src/assets/icons/gas.svg';
 import { useGasFee } from 'src/hooks/useGasFee';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useQuote } from 'src/hooks/useQuote';
-import { EitherQuoteSifiAction } from '@sifi/sdk';
+import { EitherQuoteSifiAction, Quote } from '@sifi/sdk';
 import { ReactComponent as UniswapIcon } from 'src/assets/bridges/uniswap.svg';
 import { ReactComponent as CurveIcon } from 'src/assets/bridges/curve.svg';
 import { ReactComponent as StargateIcon } from 'src/assets/bridges/stargate.svg';
 import { ReactComponent as ArrowRight } from 'src/assets/arrow-right.svg';
+
+type GasFeeProps = {
+  quote: Quote | null;
+};
+
+type PathProps = {
+  quote: Quote | null;
+};
 
 type StepDetails = {
   [key: string]: { icon: JSX.Element; name: string };
@@ -52,8 +60,8 @@ const getStepDetailsFromAction = (action: EitherQuoteSifiAction): StepInfo | nul
   return null;
 };
 
-const GasFee = () => {
-  const { gasFeeEstimateUsd } = useGasFee();
+const GasFee: React.FC<GasFeeProps> = ({ quote }) => {
+  const { gasFeeEstimateUsd } = useGasFee(quote);
 
   return (
     <div className="relative flex items-center">
@@ -81,9 +89,7 @@ const GasFee = () => {
   );
 };
 
-const Path = () => {
-  const { quote } = useQuote();
-
+const Path: React.FC<PathProps> = ({ quote }) => {
   if (!quote || !('element' in quote.source.quote) || !quote.source.quote.element.actions) {
     return null;
   }
@@ -139,12 +145,18 @@ const Path = () => {
 };
 
 const SwapDetails = () => {
+  const { quote } = useQuote();
+
   return (
     <div className="flex justify-between min-h-[1.75rem] pt-2 px-4 text-smoke">
-      <GasFee />
-      <Path />
+      {quote && (
+        <>
+          <GasFee quote={quote} />
+          <Path quote={quote} />
+        </>
+      )}
     </div>
   );
 };
 
-export { SwapDetails };
+export { SwapDetails, GasFee, Path };

--- a/packages/frontend/src/components/SwapPath/SwapPath.tsx
+++ b/packages/frontend/src/components/SwapPath/SwapPath.tsx
@@ -1,0 +1,111 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { EitherQuoteSifiAction, Quote } from '@sifi/sdk';
+import { ReactComponent as UniswapIcon } from 'src/assets/bridges/uniswap.svg';
+import { ReactComponent as CurveIcon } from 'src/assets/bridges/curve.svg';
+import { ReactComponent as StargateIcon } from 'src/assets/bridges/stargate.svg';
+import { ReactComponent as ArrowRight } from 'src/assets/arrow-right.svg';
+
+type SwapPathProps = {
+  quote: Quote | null;
+};
+
+type StepDetails = {
+  [key: string]: { icon: JSX.Element; name: string };
+};
+
+type Step = {
+  icon: JSX.Element;
+  name: string;
+};
+
+const iconClassName = 'w-4 h-4 border-smoke border rounded-full';
+
+const stepDetails: StepDetails = {
+  uniswap: { icon: <UniswapIcon className={iconClassName} />, name: 'Uniswap' },
+  stargate: { icon: <StargateIcon className={iconClassName} />, name: 'Stargate' },
+  curve: { icon: <CurveIcon className={iconClassName} />, name: 'Curve' },
+};
+
+type StepInfo = {
+  icon: JSX.Element;
+  name: string;
+};
+
+const getStepDetailsFromAction = (action: EitherQuoteSifiAction): StepInfo | null => {
+  if ('exchange' in action) {
+    const exchange = action.exchange.toLowerCase();
+
+    for (let key in stepDetails) {
+      const regex = new RegExp(key, 'i');
+
+      if (regex.test(exchange)) {
+        const detail = stepDetails[key];
+
+        if (detail) {
+          return {
+            icon: detail.icon,
+            name: detail.name,
+          };
+        }
+      }
+    }
+  }
+  return null;
+};
+
+const SwapPath: React.FC<SwapPathProps> = ({ quote }) => {
+  if (!quote || !('element' in quote.source.quote) || !quote.source.quote.element.actions) {
+    return null;
+  }
+
+  let steps: Step[] = [];
+
+  quote.source.quote.element.actions.forEach(action => {
+    if (action.type === 'split') {
+      action.parts.forEach(part => {
+        part.actions.forEach(partAction => {
+          const step = getStepDetailsFromAction(partAction);
+
+          if (!step) return;
+
+          steps.push(step);
+        });
+      });
+    } else {
+      const step = getStepDetailsFromAction(action);
+
+      if (!step) return;
+
+      steps.push(step);
+    }
+  });
+
+  // The UI can only fit 6 steps
+  steps = steps.slice(-6);
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.1 }}
+        className="flex items-center"
+      >
+        {steps.map((step, index) => (
+          <div key={index}>
+            <div className="flex text-sm items-center">
+              {step.icon && <div className="mx-1">{step.icon}</div>}
+              {step.name && steps.length < 4 && (
+                <div className="hidden xs:block ml-1">{step.name}</div>
+              )}
+              {step.icon && index !== steps.length - 1 && <ArrowRight className="w-4 mx-1" />}
+            </div>
+          </div>
+        ))}
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export { SwapPath };

--- a/packages/frontend/src/hooks/useGasFee.tsx
+++ b/packages/frontend/src/hooks/useGasFee.tsx
@@ -1,13 +1,12 @@
 import { useState, useEffect, useMemo } from 'react';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
-import { useQuote } from './useQuote';
 import { useUsdValue } from './useUsdValue';
 import { useSwapFormValues } from './useSwapFormValues';
 import { usePublicClient } from 'wagmi';
 import { formatEther } from 'viem';
+import type { Quote } from '@sifi/sdk';
 
-const useGasFee = () => {
-  const { quote } = useQuote();
+const useGasFee = (quote: Quote | null) => {
   const { fromChain } = useSwapFormValues();
   const publicClient = usePublicClient({ chainId: fromChain.id });
   const [gasPriceWei, setGasPriceWei] = useState<bigint | null>(null);


### PR DESCRIPTION
- Seprated GasFee and SwapPath components from SwapDetails so that they can be reused in #453 
- These components now depend on props instead of getting the quote via the `useQuote` hook. Needed for reusability in SwapModal.

### Testing
- No changes to the UI.

![image](https://github.com/sifiorg/sifi/assets/128667801/65c00dd6-b111-40d9-859f-6eab22b08f37)
